### PR TITLE
Ensure images are RedHat certified

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -41,6 +41,10 @@ COPY build/bin /usr/local/bin
 COPY manifests /manifests
 RUN  /usr/local/bin/user_setup
 
+# copy licenses
+RUN mkdir /licenses
+COPY LICENSE /licenses
+
 ENTRYPOINT ["/usr/local/bin/entrypoint"]
 
 USER ${USER_UID}

--- a/build/Dockerfile.ppc64le
+++ b/build/Dockerfile.ppc64le
@@ -47,6 +47,10 @@ COPY build/bin /usr/local/bin
 COPY manifests /manifests
 RUN  /usr/local/bin/user_setup
 
+# copy licenses
+RUN mkdir /licenses
+COPY LICENSE /licenses
+
 ENTRYPOINT ["/usr/local/bin/entrypoint"]
 
 USER ${USER_UID}

--- a/build/Dockerfile.s390x
+++ b/build/Dockerfile.s390x
@@ -47,6 +47,10 @@ COPY build/bin /usr/local/bin
 COPY manifests /manifests
 RUN  /usr/local/bin/user_setup
 
+# copy licenses
+RUN mkdir /licenses
+COPY LICENSE /licenses
+
 ENTRYPOINT ["/usr/local/bin/entrypoint"]
 
 USER ${USER_UID}


### PR DESCRIPTION
Add `/licenses` folder and copy LICENSE, to ensure operator image pass RedHat certification.