### PR TITLE
reduce must-gather cluster permission

### DIFF
--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.8.0/ibm-healthcheck-operator.v3.8.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.8.0/ibm-healthcheck-operator.v3.8.0.clusterserviceversion.yaml
@@ -256,7 +256,15 @@ spec:
           resources:
           - '*'
           verbs:
-          - '*'
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ''
+          resources:
+          - 'pods/exec'
+          verbs:
+          - create
         serviceAccountName: ibm-mustgather-admin
       deployments:
       - name: ibm-healthcheck-operator

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -167,4 +167,12 @@ rules:
   resources:
   - '*'
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - 'pods/exec'
+  verbs:
+  - create


### PR DESCRIPTION
**What this PR does / why we need it**:
Limit ibm-mustgather-admin to only read permission.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
```
