### PR TITLE
Fix rbac wildchar issue for  3.6 eus

### DIFF
--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.8.2/ibm-healthcheck-operator.v3.8.2.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.8.2/ibm-healthcheck-operator.v3.8.2.clusterserviceversion.yaml
@@ -237,7 +237,14 @@ spec:
           resources:
           - clusterservicestatuses
           verbs:
-          - '*'
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+          - deletecollection
         - apiGroups:
           - ''
           resources:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -135,7 +135,14 @@ rules:
   resources:
   - clusterservicestatuses
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection  
 - apiGroups:
   - ''
   resources:


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to reduce the namespace-scope operator permissions, we need the operator and operands have enumerated the required verbs. Hence part of fix , we are removing the wildchar (*) verb and specified the required verbs in the CSV as well as in the role file.

Issue https://github.ibm.com/IBMPrivateCloud/roadmap/issues/45003

Parent issue https://github.ibm.com/IBMPrivateCloud/roadmap/issues/44666

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #44666 , Fixes#45003

