### PR TITLE
bumpup operands version for 3.6 eus

### DIFF
--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.8.2/ibm-healthcheck-operator.v3.8.2.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.8.2/ibm-healthcheck-operator.v3.8.2.clusterserviceversion.yaml
@@ -319,9 +319,9 @@ spec:
                 - name: ICP_MEMCACHED_IMAGE
                   value: "quay.io/opencloudio/icp-memcached:3.9.0"
                 - name: MUST_GATHER_IMAGE
-                  value: "quay.io/opencloudio/must-gather:4.5.4"
+                  value: "quay.io/opencloudio/must-gather:4.5.5"
                 - name: MUST_GATHER_SERVICE_IMAGE
-                  value: "quay.io/opencloudio/must-gather-service:1.2.1"
+                  value: "quay.io/opencloudio/must-gather-service:1.2.2"
                 image: quay.io/opencloudio/ibm-healthcheck-operator:3.8.2
                 imagePullPolicy: Always
                 name: ibm-healthcheck-operator


### PR DESCRIPTION
**What this PR does / why we need it**:
This is to fix the openssl vulnerability for the operand ubi images.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/45842
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/45841
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/45783
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/45782

