### PR TITLE
Fix/openssl vulnerability to master

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -61,9 +61,9 @@ spec:
             - name: ICP_MEMCACHED_IMAGE
               value: "quay.io/opencloudio/icp-memcached:3.9.0"
             - name: MUST_GATHER_IMAGE
-              value: "quay.io/opencloudio/must-gather:4.5.4"
+              value: "quay.io/opencloudio/must-gather:4.5.5"
             - name: MUST_GATHER_SERVICE_IMAGE
-              value: "quay.io/opencloudio/must-gather-service:1.2.1"
+              value: "quay.io/opencloudio/must-gather-service:1.2.2"
           resources:
             limits:
               cpu: 160m


### PR DESCRIPTION
What this PR does / why we need it:
This is to fix the openssl vulnerability for the operand ubi images.

Parent PR
https://github.com/IBM/ibm-healthcheck-operator/pull/121

Which issue(s) this PR fixes (optional, in fixes #(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/45842
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/45841
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/45783
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/45782