### PR TITLE
Removed deprecated node-selector label

### DIFF
--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.10.0/ibm-healthcheck-operator.v3.10.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.10.0/ibm-healthcheck-operator.v3.10.0.clusterserviceversion.yaml
@@ -294,7 +294,7 @@ spec:
                   requiredDuringSchedulingIgnoredDuringExecution:
                     nodeSelectorTerms:
                     - matchExpressions:
-                      - key: beta.kubernetes.io/arch
+                      - key: kubernetes.io/arch
                         operator: In
                         values:
                         - amd64

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -29,7 +29,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - amd64


### PR DESCRIPTION
**What this PR does / why we need it**:
Removing the deprecated node-selector label.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/46216