### PR TITLE
Reverting NoDeprecatedAPIs CRD changes

### DIFF
--- a/deploy/crds/clusterhealth.ibm.com_clusterservicestatuses_crd.yaml
+++ b/deploy/crds/clusterhealth.ibm.com_clusterservicestatuses_crd.yaml
@@ -4,7 +4,7 @@
 # US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
 ###############################################################################
 
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: clusterservicestatuses.clusterhealth.ibm.com

--- a/deploy/crds/operator.ibm.com_healthservices_crd.yaml
+++ b/deploy/crds/operator.ibm.com_healthservices_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: healthservices.operator.ibm.com

--- a/deploy/crds/operator.ibm.com_mustgatherconfigs_crd.yaml
+++ b/deploy/crds/operator.ibm.com_mustgatherconfigs_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: mustgatherconfigs.operator.ibm.com

--- a/deploy/crds/operator.ibm.com_mustgatherjobs_crd.yaml
+++ b/deploy/crds/operator.ibm.com_mustgatherjobs_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: mustgatherjobs.operator.ibm.com

--- a/deploy/crds/operator.ibm.com_mustgatherservices_crd.yaml
+++ b/deploy/crds/operator.ibm.com_mustgatherservices_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: mustgatherservices.operator.ibm.com

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.10.0/clusterhealth.ibm.com_clusterservicestatuses_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.10.0/clusterhealth.ibm.com_clusterservicestatuses_crd.yaml
@@ -4,7 +4,7 @@
 # US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
 ###############################################################################
 
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: clusterservicestatuses.clusterhealth.ibm.com

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.10.0/ibm-healthcheck-operator.v3.10.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.10.0/ibm-healthcheck-operator.v3.10.0.clusterserviceversion.yaml
@@ -157,16 +157,16 @@ metadata:
     operatorframework.io/os.linux: supported
 spec:
   relatedImages:
-     - name: ibm-healthcheck-operator
-       image: quay.io/opencloudio/ibm-healthcheck-operator:latest
-     - name: SYSTEM_HEALTHCHECK_SERVICE_IMAGE
-       image: quay.io/opencloudio/system-healthcheck-service:3.9.1
-     - name: ICP_MEMCACHED_IMAGE
-       image: quay.io/opencloudio/icp-memcached:3.9.0
-     - name: MUST_GATHER_IMAGE
-       image: quay.io/opencloudio/must-gather:4.5.5
-     - name: MUST_GATHER_SERVICE_IMAGE
-       image: quay.io/opencloudio/must-gather-service:1.2.2
+    - name: ibm-healthcheck-operator
+      image: quay.io/opencloudio/ibm-healthcheck-operator:latest
+    - name: SYSTEM_HEALTHCHECK_SERVICE_IMAGE
+      image: quay.io/opencloudio/system-healthcheck-service:3.9.1
+    - name: ICP_MEMCACHED_IMAGE
+      image: quay.io/opencloudio/icp-memcached:3.9.0
+    - name: MUST_GATHER_IMAGE
+      image: quay.io/opencloudio/must-gather:4.5.5
+    - name: MUST_GATHER_SERVICE_IMAGE
+      image: quay.io/opencloudio/must-gather-service:1.2.2
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.10.0/operator.ibm.com_healthservices_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.10.0/operator.ibm.com_healthservices_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: healthservices.operator.ibm.com

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.10.0/operator.ibm.com_mustgatherconfigs_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.10.0/operator.ibm.com_mustgatherconfigs_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: mustgatherconfigs.operator.ibm.com

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.10.0/operator.ibm.com_mustgatherjobs_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.10.0/operator.ibm.com_mustgatherjobs_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: mustgatherjobs.operator.ibm.com

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.10.0/operator.ibm.com_mustgatherservices_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.10.0/operator.ibm.com_mustgatherservices_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: mustgatherservices.operator.ibm.com

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.5.0/clusterhealth.ibm.com_clusterservicestatuses_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.5.0/clusterhealth.ibm.com_clusterservicestatuses_crd.yaml
@@ -4,7 +4,7 @@
 # US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
 ###############################################################################
 
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: clusterservicestatuses.clusterhealth.ibm.com

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.5.0/operator.ibm.com_healthservices_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.5.0/operator.ibm.com_healthservices_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: healthservices.operator.ibm.com

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.6.0/clusterhealth.ibm.com_clusterservicestatuses_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.6.0/clusterhealth.ibm.com_clusterservicestatuses_crd.yaml
@@ -4,7 +4,7 @@
 # US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
 ###############################################################################
 
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: clusterservicestatuses.clusterhealth.ibm.com

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.6.0/operator.ibm.com_healthservices_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.6.0/operator.ibm.com_healthservices_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: healthservices.operator.ibm.com

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.6.1/clusterhealth.ibm.com_clusterservicestatuses_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.6.1/clusterhealth.ibm.com_clusterservicestatuses_crd.yaml
@@ -4,7 +4,7 @@
 # US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
 ###############################################################################
 
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: clusterservicestatuses.clusterhealth.ibm.com

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.6.1/operator.ibm.com_healthservices_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.6.1/operator.ibm.com_healthservices_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: healthservices.operator.ibm.com

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.7.0/clusterhealth.ibm.com_clusterservicestatuses_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.7.0/clusterhealth.ibm.com_clusterservicestatuses_crd.yaml
@@ -4,7 +4,7 @@
 # US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
 ###############################################################################
 
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: clusterservicestatuses.clusterhealth.ibm.com

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.7.0/operator.ibm.com_healthservices_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.7.0/operator.ibm.com_healthservices_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: healthservices.operator.ibm.com

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.7.0/operator.ibm.com_mustgatherconfigs_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.7.0/operator.ibm.com_mustgatherconfigs_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: mustgatherconfigs.operator.ibm.com

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.7.0/operator.ibm.com_mustgatherjobs_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.7.0/operator.ibm.com_mustgatherjobs_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: mustgatherjobs.operator.ibm.com

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.7.0/operator.ibm.com_mustgatherservices_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.7.0/operator.ibm.com_mustgatherservices_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: mustgatherservices.operator.ibm.com

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.7.1/clusterhealth.ibm.com_clusterservicestatuses_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.7.1/clusterhealth.ibm.com_clusterservicestatuses_crd.yaml
@@ -4,7 +4,7 @@
 # US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
 ###############################################################################
 
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: clusterservicestatuses.clusterhealth.ibm.com

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.7.1/operator.ibm.com_healthservices_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.7.1/operator.ibm.com_healthservices_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: healthservices.operator.ibm.com

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.7.1/operator.ibm.com_mustgatherconfigs_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.7.1/operator.ibm.com_mustgatherconfigs_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: mustgatherconfigs.operator.ibm.com

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.7.1/operator.ibm.com_mustgatherjobs_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.7.1/operator.ibm.com_mustgatherjobs_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: mustgatherjobs.operator.ibm.com

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.7.1/operator.ibm.com_mustgatherservices_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.7.1/operator.ibm.com_mustgatherservices_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: mustgatherservices.operator.ibm.com

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.7.2/clusterhealth.ibm.com_clusterservicestatuses_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.7.2/clusterhealth.ibm.com_clusterservicestatuses_crd.yaml
@@ -4,7 +4,7 @@
 # US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
 ###############################################################################
 
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: clusterservicestatuses.clusterhealth.ibm.com

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.7.2/operator.ibm.com_healthservices_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.7.2/operator.ibm.com_healthservices_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: healthservices.operator.ibm.com

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.7.2/operator.ibm.com_mustgatherconfigs_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.7.2/operator.ibm.com_mustgatherconfigs_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: mustgatherconfigs.operator.ibm.com

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.7.2/operator.ibm.com_mustgatherjobs_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.7.2/operator.ibm.com_mustgatherjobs_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: mustgatherjobs.operator.ibm.com

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.7.2/operator.ibm.com_mustgatherservices_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.7.2/operator.ibm.com_mustgatherservices_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: mustgatherservices.operator.ibm.com

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.8.0/clusterhealth.ibm.com_clusterservicestatuses_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.8.0/clusterhealth.ibm.com_clusterservicestatuses_crd.yaml
@@ -4,7 +4,7 @@
 # US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
 ###############################################################################
 
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: clusterservicestatuses.clusterhealth.ibm.com

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.8.0/operator.ibm.com_healthservices_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.8.0/operator.ibm.com_healthservices_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: healthservices.operator.ibm.com

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.8.0/operator.ibm.com_mustgatherconfigs_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.8.0/operator.ibm.com_mustgatherconfigs_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: mustgatherconfigs.operator.ibm.com

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.8.0/operator.ibm.com_mustgatherjobs_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.8.0/operator.ibm.com_mustgatherjobs_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: mustgatherjobs.operator.ibm.com

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.8.0/operator.ibm.com_mustgatherservices_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.8.0/operator.ibm.com_mustgatherservices_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: mustgatherservices.operator.ibm.com

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.8.1/clusterhealth.ibm.com_clusterservicestatuses_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.8.1/clusterhealth.ibm.com_clusterservicestatuses_crd.yaml
@@ -4,7 +4,7 @@
 # US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
 ###############################################################################
 
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: clusterservicestatuses.clusterhealth.ibm.com

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.8.1/operator.ibm.com_healthservices_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.8.1/operator.ibm.com_healthservices_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: healthservices.operator.ibm.com

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.8.1/operator.ibm.com_mustgatherconfigs_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.8.1/operator.ibm.com_mustgatherconfigs_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: mustgatherconfigs.operator.ibm.com

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.8.1/operator.ibm.com_mustgatherjobs_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.8.1/operator.ibm.com_mustgatherjobs_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: mustgatherjobs.operator.ibm.com

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.8.1/operator.ibm.com_mustgatherservices_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.8.1/operator.ibm.com_mustgatherservices_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: mustgatherservices.operator.ibm.com

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.9.0/clusterhealth.ibm.com_clusterservicestatuses_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.9.0/clusterhealth.ibm.com_clusterservicestatuses_crd.yaml
@@ -4,7 +4,7 @@
 # US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
 ###############################################################################
 
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: clusterservicestatuses.clusterhealth.ibm.com

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.9.0/operator.ibm.com_healthservices_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.9.0/operator.ibm.com_healthservices_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: healthservices.operator.ibm.com

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.9.0/operator.ibm.com_mustgatherconfigs_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.9.0/operator.ibm.com_mustgatherconfigs_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: mustgatherconfigs.operator.ibm.com

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.9.0/operator.ibm.com_mustgatherjobs_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.9.0/operator.ibm.com_mustgatherjobs_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: mustgatherjobs.operator.ibm.com

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.9.0/operator.ibm.com_mustgatherservices_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.9.0/operator.ibm.com_mustgatherservices_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: mustgatherservices.operator.ibm.com

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.9.1/clusterhealth.ibm.com_clusterservicestatuses_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.9.1/clusterhealth.ibm.com_clusterservicestatuses_crd.yaml
@@ -4,7 +4,7 @@
 # US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
 ###############################################################################
 
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: clusterservicestatuses.clusterhealth.ibm.com

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.9.1/operator.ibm.com_healthservices_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.9.1/operator.ibm.com_healthservices_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: healthservices.operator.ibm.com

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.9.1/operator.ibm.com_mustgatherconfigs_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.9.1/operator.ibm.com_mustgatherconfigs_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: mustgatherconfigs.operator.ibm.com

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.9.1/operator.ibm.com_mustgatherjobs_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.9.1/operator.ibm.com_mustgatherjobs_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: mustgatherjobs.operator.ibm.com

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.9.1/operator.ibm.com_mustgatherservices_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.9.1/operator.ibm.com_mustgatherservices_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: mustgatherservices.operator.ibm.com


### PR DESCRIPTION
**What this PR does / why we need it**:
1. Revert the CRD changes due to build issue  raised on earlier PR https://github.com/IBM/ibm-healthcheck-operator/pull/128
2. Removed extra space for the CSV file (3.10.0) for `CSVHasValidRelatedImages` rule

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/47287
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/46434
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/47086