### PR TITLE
Updated UBI image for CVE-2021-27219

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3-230
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4-200.1622548483
 ARG VCS_REF
 ARG VCS_URL
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix for CVE-2021-27219	package glib2

Latest UBI images to be used to fix this -

Latest ubi8/ubi8min images
- registry.access.redhat.com/ubi8/ubi:8.4-203.1622660121						
- registry.access.redhat.com/ubi8/ubi-minimal:8.4-200.1622548483