### PR TITLE
Change minKubeVersion from 1.19 to 1.19.0

### DIFF
--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.11.0/ibm-healthcheck-operator.v3.11.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.11.0/ibm-healthcheck-operator.v3.11.0.clusterserviceversion.yaml
@@ -458,7 +458,7 @@ spec:
   - supported: true
     type: AllNamespaces
   maturity: alpha
-  minKubeVersion: 1.19
+  minKubeVersion: 1.19.0
   provider:
     name: IBM
   replaces: ibm-healthcheck-operator.v3.10.0


### PR DESCRIPTION
**What this PR does / why we need it**:
According to this CICD sev 1 issue #47852, we find we need to set the minikubeversion to 1.19.0 instead of 1.19
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
```
