### PR TITLE
K8S crd api update to v1

### DIFF
--- a/deploy/crds/clusterhealth.ibm.com_clusterservicestatuses_crd.yaml
+++ b/deploy/crds/clusterhealth.ibm.com_clusterservicestatuses_crd.yaml
@@ -4,7 +4,7 @@
 # US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
 ###############################################################################
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clusterservicestatuses.clusterhealth.ibm.com
@@ -18,7 +18,40 @@ spec:
     - name: v1
       served: true
       storage: true
-  version: v1
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            status:
+              type: object
+              properties:
+                currentState:
+                  type: string
+                restartCount:
+                  type: integer
+                statusDependencies:
+                  type: array
+                  items: {
+                    type: string
+                  }
+                podFailureStatus:
+                  type: object
+      additionalPrinterColumns:
+      -
+        name: Service Name
+        type: string
+        description: The name of the service
+        jsonPath: .metadata.labels.clusterhealth\.ibm\.com/service-name
+      -
+        name: Service Version
+        type: string
+        description: The version of the service
+        jsonPath: .metadata.labels.clusterhealth\.ibm\.com/service-version
+      -
+        name: Status
+        type: string
+        description: The current status of the service
+        jsonPath: .status.currentState                        
   scope: Cluster
   names:
     kind: ClusterServiceStatus
@@ -26,35 +59,3 @@ spec:
     plural: clusterservicestatuses
     shortNames:
     - css
-  additionalPrinterColumns:
-  -
-    name: Service Name
-    type: string
-    description: The name of the service
-    JSONPath: .metadata.labels.clusterhealth\.ibm\.com/service-name
-  -
-    name: Service Version
-    type: string
-    description: The version of the service
-    JSONPath: .metadata.labels.clusterhealth\.ibm\.com/service-version
-  -
-    name: Status
-    type: string
-    description: The current status of the service
-    JSONPath: .status.currentState
-  validation:
-    openAPIV3Schema:
-      properties:
-        status:
-          properties:
-            currentState:
-              type: string
-            restartCount:
-              type: integer
-            statusDependencies:
-              type: array
-              items: {
-                type: string
-              }
-            podFailureStatus:
-              type: object

--- a/deploy/crds/operator.ibm.com_healthservices_crd.yaml
+++ b/deploy/crds/operator.ibm.com_healthservices_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: healthservices.operator.ibm.com
@@ -14,507 +14,506 @@ spec:
     plural: healthservices
     singular: healthservice
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: HealthService is the Schema for the healthservices API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: HealthServiceSpec defines the desired state of HealthService
-          properties:
-            healthService:
-              description: HealthService defines the desired state of HealthService.HealthService
-              properties:
-                cloudpakNameSetting:
-                  description: set labels/annotation name to get pod's cloudpakname
-                  type: string
-                configmapName:
-                  description: configmap which contains health srevice configuration
-                    files, deprecated
-                  type: string
-                dependsSetting:
-                  description: set labels/annotation name to get pod's dependencies
-                  type: string
-                hostNetwork:
-                  description: health srevice deployment hostnetwork, default is false
-                  type: boolean
-                image:
-                  description: deprecated, define image in operator.yaml
-                  properties:
-                    pullPolicy:
-                      description: image pull policy, default is IfNotPresent
-                      type: string
-                    repository:
-                      description: image repository, default is empty
-                      type: string
-                    tag:
-                      description: image tag, default is empty
-                      type: string
-                  required:
-                  - repository
-                  - tag
-                  type: object
-                name:
-                  description: health service deployment name
-                  type: string
-                nodeSelector:
-                  additionalProperties:
-                    type: string
-                  description: health srevice deployment node selector, default is
-                    empty
-                  type: object
-                replicas:
-                  description: health service pod replicas, default is 1
-                  format: int32
-                  type: integer
-                resources:
-                  description: resources defines the desired state of Resources
-                  properties:
-                    limits:
-                      properties:
-                        cpu:
-                          type: string
-                        memory:
-                          type: string
-                      type: object
-                    requests:
-                      properties:
-                        cpu:
-                          type: string
-                        memory:
-                          type: string
-                      type: object
-                  type: object
-                securityContext:
-                  description: memcached deployment security context, default is empty
-                  properties:
-                    allowPrivilegeEscalation:
-                      description: 'AllowPrivilegeEscalation controls whether a process
-                        can gain more privileges than its parent process. This bool
-                        directly controls if the no_new_privs flag will be set on
-                        the container process. AllowPrivilegeEscalation is true always
-                        when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
-                      type: boolean
-                    capabilities:
-                      description: The capabilities to add/drop when running containers.
-                        Defaults to the default set of capabilities granted by the
-                        container runtime.
-                      properties:
-                        add:
-                          description: Added capabilities
-                          items:
-                            description: Capability represent POSIX capabilities type
-                            type: string
-                          type: array
-                        drop:
-                          description: Removed capabilities
-                          items:
-                            description: Capability represent POSIX capabilities type
-                            type: string
-                          type: array
-                      type: object
-                    privileged:
-                      description: Run container in privileged mode. Processes in
-                        privileged containers are essentially equivalent to root on
-                        the host. Defaults to false.
-                      type: boolean
-                    procMount:
-                      description: procMount denotes the type of proc mount to use
-                        for the containers. The default is DefaultProcMount which
-                        uses the container runtime defaults for readonly paths and
-                        masked paths. This requires the ProcMountType feature flag
-                        to be enabled.
-                      type: string
-                    readOnlyRootFilesystem:
-                      description: Whether this container has a read-only root filesystem.
-                        Default is false.
-                      type: boolean
-                    runAsGroup:
-                      description: The GID to run the entrypoint of the container
-                        process. Uses runtime default if unset. May also be set in
-                        PodSecurityContext.  If set in both SecurityContext and PodSecurityContext,
-                        the value specified in SecurityContext takes precedence.
-                      format: int64
-                      type: integer
-                    runAsNonRoot:
-                      description: Indicates that the container must run as a non-root
-                        user. If true, the Kubelet will validate the image at runtime
-                        to ensure that it does not run as UID 0 (root) and fail to
-                        start the container if it does. If unset or false, no such
-                        validation will be performed. May also be set in PodSecurityContext.  If
-                        set in both SecurityContext and PodSecurityContext, the value
-                        specified in SecurityContext takes precedence.
-                      type: boolean
-                    runAsUser:
-                      description: The UID to run the entrypoint of the container
-                        process. Defaults to user specified in image metadata if unspecified.
-                        May also be set in PodSecurityContext.  If set in both SecurityContext
-                        and PodSecurityContext, the value specified in SecurityContext
-                        takes precedence.
-                      format: int64
-                      type: integer
-                    seLinuxOptions:
-                      description: The SELinux context to be applied to the container.
-                        If unspecified, the container runtime will allocate a random
-                        SELinux context for each container.  May also be set in PodSecurityContext.  If
-                        set in both SecurityContext and PodSecurityContext, the value
-                        specified in SecurityContext takes precedence.
-                      properties:
-                        level:
-                          description: Level is SELinux level label that applies to
-                            the container.
-                          type: string
-                        role:
-                          description: Role is a SELinux role label that applies to
-                            the container.
-                          type: string
-                        type:
-                          description: Type is a SELinux type label that applies to
-                            the container.
-                          type: string
-                        user:
-                          description: User is a SELinux user label that applies to
-                            the container.
-                          type: string
-                      type: object
-                    windowsOptions:
-                      description: The Windows specific settings applied to all containers.
-                        If unspecified, the options from the PodSecurityContext will
-                        be used. If set in both SecurityContext and PodSecurityContext,
-                        the value specified in SecurityContext takes precedence.
-                      properties:
-                        gmsaCredentialSpec:
-                          description: GMSACredentialSpec is where the GMSA admission
-                            webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                            inlines the contents of the GMSA credential spec named
-                            by the GMSACredentialSpecName field. This field is alpha-level
-                            and is only honored by servers that enable the WindowsGMSA
-                            feature flag.
-                          type: string
-                        gmsaCredentialSpecName:
-                          description: GMSACredentialSpecName is the name of the GMSA
-                            credential spec to use. This field is alpha-level and
-                            is only honored by servers that enable the WindowsGMSA
-                            feature flag.
-                          type: string
-                        runAsUserName:
-                          description: The UserName in Windows to run the entrypoint
-                            of the container process. Defaults to the user specified
-                            in image metadata if unspecified. May also be set in PodSecurityContext.
-                            If set in both SecurityContext and PodSecurityContext,
-                            the value specified in SecurityContext takes precedence.
-                            This field is alpha-level and it is only honored by servers
-                            that enable the WindowsRunAsUserName feature flag.
-                          type: string
-                      type: object
-                  type: object
-                serviceAccountName:
-                  description: health service deployment ServiceAccountName, default
-                    is default
-                  type: string
-                serviceNameSetting:
-                  description: set labels/annotation name to get pod's servicename
-                  type: string
-                tolerations:
-                  description: health srevice deployment tolerations, default is empty
-                  items:
-                    description: The pod this Toleration is attached to tolerates
-                      any taint that matches the triple <key,value,effect> using the
-                      matching operator <operator>.
-                    properties:
-                      effect:
-                        description: Effect indicates the taint effect to match. Empty
-                          means match all taint effects. When specified, allowed values
-                          are NoSchedule, PreferNoSchedule and NoExecute.
-                        type: string
-                      key:
-                        description: Key is the taint key that the toleration applies
-                          to. Empty means match all taint keys. If the key is empty,
-                          operator must be Exists; this combination means to match
-                          all values and all keys.
-                        type: string
-                      operator:
-                        description: Operator represents a key's relationship to the
-                          value. Valid operators are Exists and Equal. Defaults to
-                          Equal. Exists is equivalent to wildcard for value, so that
-                          a pod can tolerate all taints of a particular category.
-                        type: string
-                      tolerationSeconds:
-                        description: TolerationSeconds represents the period of time
-                          the toleration (which must be of effect NoExecute, otherwise
-                          this field is ignored) tolerates the taint. By default,
-                          it is not set, which means tolerate the taint forever (do
-                          not evict). Zero and negative values will be treated as
-                          0 (evict immediately) by the system.
-                        format: int64
-                        type: integer
-                      value:
-                        description: Value is the taint value the toleration matches
-                          to. If the operator is Exists, the value should be empty,
-                          otherwise just a regular string.
-                        type: string
-                    type: object
-                  type: array
-              required:
-              - configmapName
-              - name
-              type: object
-            memcached:
-              description: Memcached defines the desired state of HealthService.Memcached
-              properties:
-                command:
-                  description: memcached startup command, default value is "memcached
-                    -m 64 -o modern -v"
-                  items:
-                    type: string
-                  type: array
-                image:
-                  description: deprecated, define image in operator.yaml
-                  properties:
-                    pullPolicy:
-                      description: image pull policy, default is IfNotPresent
-                      type: string
-                    repository:
-                      description: image repository, default is empty
-                      type: string
-                    tag:
-                      description: image tag, default is empty
-                      type: string
-                  required:
-                  - repository
-                  - tag
-                  type: object
-                name:
-                  description: memcached deployment name
-                  type: string
-                nodeSelector:
-                  additionalProperties:
-                    type: string
-                  description: memcached deployment node selector, default is empty
-                  type: object
-                replicas:
-                  description: memcached pod replicas, default is 1
-                  format: int32
-                  type: integer
-                resources:
-                  description: resources defines the desired state of Resources
-                  properties:
-                    limits:
-                      properties:
-                        cpu:
-                          type: string
-                        memory:
-                          type: string
-                      type: object
-                    requests:
-                      properties:
-                        cpu:
-                          type: string
-                        memory:
-                          type: string
-                      type: object
-                  type: object
-                securityContext:
-                  description: memcached deployment security context, default is empty
-                  properties:
-                    allowPrivilegeEscalation:
-                      description: 'AllowPrivilegeEscalation controls whether a process
-                        can gain more privileges than its parent process. This bool
-                        directly controls if the no_new_privs flag will be set on
-                        the container process. AllowPrivilegeEscalation is true always
-                        when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
-                      type: boolean
-                    capabilities:
-                      description: The capabilities to add/drop when running containers.
-                        Defaults to the default set of capabilities granted by the
-                        container runtime.
-                      properties:
-                        add:
-                          description: Added capabilities
-                          items:
-                            description: Capability represent POSIX capabilities type
-                            type: string
-                          type: array
-                        drop:
-                          description: Removed capabilities
-                          items:
-                            description: Capability represent POSIX capabilities type
-                            type: string
-                          type: array
-                      type: object
-                    privileged:
-                      description: Run container in privileged mode. Processes in
-                        privileged containers are essentially equivalent to root on
-                        the host. Defaults to false.
-                      type: boolean
-                    procMount:
-                      description: procMount denotes the type of proc mount to use
-                        for the containers. The default is DefaultProcMount which
-                        uses the container runtime defaults for readonly paths and
-                        masked paths. This requires the ProcMountType feature flag
-                        to be enabled.
-                      type: string
-                    readOnlyRootFilesystem:
-                      description: Whether this container has a read-only root filesystem.
-                        Default is false.
-                      type: boolean
-                    runAsGroup:
-                      description: The GID to run the entrypoint of the container
-                        process. Uses runtime default if unset. May also be set in
-                        PodSecurityContext.  If set in both SecurityContext and PodSecurityContext,
-                        the value specified in SecurityContext takes precedence.
-                      format: int64
-                      type: integer
-                    runAsNonRoot:
-                      description: Indicates that the container must run as a non-root
-                        user. If true, the Kubelet will validate the image at runtime
-                        to ensure that it does not run as UID 0 (root) and fail to
-                        start the container if it does. If unset or false, no such
-                        validation will be performed. May also be set in PodSecurityContext.  If
-                        set in both SecurityContext and PodSecurityContext, the value
-                        specified in SecurityContext takes precedence.
-                      type: boolean
-                    runAsUser:
-                      description: The UID to run the entrypoint of the container
-                        process. Defaults to user specified in image metadata if unspecified.
-                        May also be set in PodSecurityContext.  If set in both SecurityContext
-                        and PodSecurityContext, the value specified in SecurityContext
-                        takes precedence.
-                      format: int64
-                      type: integer
-                    seLinuxOptions:
-                      description: The SELinux context to be applied to the container.
-                        If unspecified, the container runtime will allocate a random
-                        SELinux context for each container.  May also be set in PodSecurityContext.  If
-                        set in both SecurityContext and PodSecurityContext, the value
-                        specified in SecurityContext takes precedence.
-                      properties:
-                        level:
-                          description: Level is SELinux level label that applies to
-                            the container.
-                          type: string
-                        role:
-                          description: Role is a SELinux role label that applies to
-                            the container.
-                          type: string
-                        type:
-                          description: Type is a SELinux type label that applies to
-                            the container.
-                          type: string
-                        user:
-                          description: User is a SELinux user label that applies to
-                            the container.
-                          type: string
-                      type: object
-                    windowsOptions:
-                      description: The Windows specific settings applied to all containers.
-                        If unspecified, the options from the PodSecurityContext will
-                        be used. If set in both SecurityContext and PodSecurityContext,
-                        the value specified in SecurityContext takes precedence.
-                      properties:
-                        gmsaCredentialSpec:
-                          description: GMSACredentialSpec is where the GMSA admission
-                            webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                            inlines the contents of the GMSA credential spec named
-                            by the GMSACredentialSpecName field. This field is alpha-level
-                            and is only honored by servers that enable the WindowsGMSA
-                            feature flag.
-                          type: string
-                        gmsaCredentialSpecName:
-                          description: GMSACredentialSpecName is the name of the GMSA
-                            credential spec to use. This field is alpha-level and
-                            is only honored by servers that enable the WindowsGMSA
-                            feature flag.
-                          type: string
-                        runAsUserName:
-                          description: The UserName in Windows to run the entrypoint
-                            of the container process. Defaults to the user specified
-                            in image metadata if unspecified. May also be set in PodSecurityContext.
-                            If set in both SecurityContext and PodSecurityContext,
-                            the value specified in SecurityContext takes precedence.
-                            This field is alpha-level and it is only honored by servers
-                            that enable the WindowsRunAsUserName feature flag.
-                          type: string
-                      type: object
-                  type: object
-                serviceAccountName:
-                  description: memcached deployment ServiceAccountName, default is
-                    default
-                  type: string
-                tolerations:
-                  description: memcached deployment tolerations, default is empty
-                  items:
-                    description: The pod this Toleration is attached to tolerates
-                      any taint that matches the triple <key,value,effect> using the
-                      matching operator <operator>.
-                    properties:
-                      effect:
-                        description: Effect indicates the taint effect to match. Empty
-                          means match all taint effects. When specified, allowed values
-                          are NoSchedule, PreferNoSchedule and NoExecute.
-                        type: string
-                      key:
-                        description: Key is the taint key that the toleration applies
-                          to. Empty means match all taint keys. If the key is empty,
-                          operator must be Exists; this combination means to match
-                          all values and all keys.
-                        type: string
-                      operator:
-                        description: Operator represents a key's relationship to the
-                          value. Valid operators are Exists and Equal. Defaults to
-                          Equal. Exists is equivalent to wildcard for value, so that
-                          a pod can tolerate all taints of a particular category.
-                        type: string
-                      tolerationSeconds:
-                        description: TolerationSeconds represents the period of time
-                          the toleration (which must be of effect NoExecute, otherwise
-                          this field is ignored) tolerates the taint. By default,
-                          it is not set, which means tolerate the taint forever (do
-                          not evict). Zero and negative values will be treated as
-                          0 (evict immediately) by the system.
-                        format: int64
-                        type: integer
-                      value:
-                        description: Value is the taint value the toleration matches
-                          to. If the operator is Exists, the value should be empty,
-                          otherwise just a regular string.
-                        type: string
-                    type: object
-                  type: array
-              required:
-              - name
-              type: object
-          type: object
-        status:
-          description: HealthServiceStatus defines the observed state of HealthService
-          properties:
-            healthCheckNodes:
-              description: HealthCheckNodes are the names of the Healch Service pods
-              items:
-                type: string
-              type: array
-            memcachedNodes:
-              description: MemcachedNodes are the names of the memcached pods
-              items:
-                type: string
-              type: array
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
     served: true
     storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        description: HealthService is the Schema for the healthservices API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HealthServiceSpec defines the desired state of HealthService
+            properties:
+              healthService:
+                description: HealthService defines the desired state of HealthService.HealthService
+                properties:
+                  cloudpakNameSetting:
+                    description: set labels/annotation name to get pod's cloudpakname
+                    type: string
+                  configmapName:
+                    description: configmap which contains health srevice configuration
+                      files, deprecated
+                    type: string
+                  dependsSetting:
+                    description: set labels/annotation name to get pod's dependencies
+                    type: string
+                  hostNetwork:
+                    description: health srevice deployment hostnetwork, default is false
+                    type: boolean
+                  image:
+                    description: deprecated, define image in operator.yaml
+                    properties:
+                      pullPolicy:
+                        description: image pull policy, default is IfNotPresent
+                        type: string
+                      repository:
+                        description: image repository, default is empty
+                        type: string
+                      tag:
+                        description: image tag, default is empty
+                        type: string
+                    required:
+                    - repository
+                    - tag
+                    type: object
+                  name:
+                    description: health service deployment name
+                    type: string
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: health srevice deployment node selector, default is
+                      empty
+                    type: object
+                  replicas:
+                    description: health service pod replicas, default is 1
+                    format: int32
+                    type: integer
+                  resources:
+                    description: resources defines the desired state of Resources
+                    properties:
+                      limits:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                        type: object
+                      requests:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                        type: object
+                    type: object
+                  securityContext:
+                    description: memcached deployment security context, default is empty
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: 'AllowPrivilegeEscalation controls whether a process
+                          can gain more privileges than its parent process. This bool
+                          directly controls if the no_new_privs flag will be set on
+                          the container process. AllowPrivilegeEscalation is true always
+                          when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                        type: boolean
+                      capabilities:
+                        description: The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the
+                          container runtime.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities type
+                              type: string
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities type
+                              type: string
+                            type: array
+                        type: object
+                      privileged:
+                        description: Run container in privileged mode. Processes in
+                          privileged containers are essentially equivalent to root on
+                          the host. Defaults to false.
+                        type: boolean
+                      procMount:
+                        description: procMount denotes the type of proc mount to use
+                          for the containers. The default is DefaultProcMount which
+                          uses the container runtime defaults for readonly paths and
+                          masked paths. This requires the ProcMountType feature flag
+                          to be enabled.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: Whether this container has a read-only root filesystem.
+                          Default is false.
+                        type: boolean
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set in
+                          PodSecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail to
+                          start the container if it does. If unset or false, no such
+                          validation will be performed. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if unspecified.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext
+                          and PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to the container.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies to
+                              the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies to
+                              the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies to
+                              the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies to
+                              the container.
+                            type: string
+                        type: object
+                      windowsOptions:
+                        description: The Windows specific settings applied to all containers.
+                          If unspecified, the options from the PodSecurityContext will
+                          be used. If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field. This field is alpha-level
+                              and is only honored by servers that enable the WindowsGMSA
+                              feature flag.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the GMSA
+                              credential spec to use. This field is alpha-level and
+                              is only honored by servers that enable the WindowsGMSA
+                              feature flag.
+                            type: string
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in PodSecurityContext.
+                              If set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence.
+                              This field is alpha-level and it is only honored by servers
+                              that enable the WindowsRunAsUserName feature flag.
+                            type: string
+                        type: object
+                    type: object
+                  serviceAccountName:
+                    description: health service deployment ServiceAccountName, default
+                      is default
+                    type: string
+                  serviceNameSetting:
+                    description: set labels/annotation name to get pod's servicename
+                    type: string
+                  tolerations:
+                    description: health srevice deployment tolerations, default is empty
+                    items:
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using the
+                        matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match. Empty
+                            means match all taint effects. When specified, allowed values
+                            are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to the
+                            value. Valid operators are Exists and Equal. Defaults to
+                            Equal. Exists is equivalent to wildcard for value, so that
+                            a pod can tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of time
+                            the toleration (which must be of effect NoExecute, otherwise
+                            this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do
+                            not evict). Zero and negative values will be treated as
+                            0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                required:
+                - configmapName
+                - name
+                type: object
+              memcached:
+                description: Memcached defines the desired state of HealthService.Memcached
+                properties:
+                  command:
+                    description: memcached startup command, default value is "memcached
+                      -m 64 -o modern -v"
+                    items:
+                      type: string
+                    type: array
+                  image:
+                    description: deprecated, define image in operator.yaml
+                    properties:
+                      pullPolicy:
+                        description: image pull policy, default is IfNotPresent
+                        type: string
+                      repository:
+                        description: image repository, default is empty
+                        type: string
+                      tag:
+                        description: image tag, default is empty
+                        type: string
+                    required:
+                    - repository
+                    - tag
+                    type: object
+                  name:
+                    description: memcached deployment name
+                    type: string
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: memcached deployment node selector, default is empty
+                    type: object
+                  replicas:
+                    description: memcached pod replicas, default is 1
+                    format: int32
+                    type: integer
+                  resources:
+                    description: resources defines the desired state of Resources
+                    properties:
+                      limits:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                        type: object
+                      requests:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                        type: object
+                    type: object
+                  securityContext:
+                    description: memcached deployment security context, default is empty
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: 'AllowPrivilegeEscalation controls whether a process
+                          can gain more privileges than its parent process. This bool
+                          directly controls if the no_new_privs flag will be set on
+                          the container process. AllowPrivilegeEscalation is true always
+                          when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                        type: boolean
+                      capabilities:
+                        description: The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the
+                          container runtime.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities type
+                              type: string
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities type
+                              type: string
+                            type: array
+                        type: object
+                      privileged:
+                        description: Run container in privileged mode. Processes in
+                          privileged containers are essentially equivalent to root on
+                          the host. Defaults to false.
+                        type: boolean
+                      procMount:
+                        description: procMount denotes the type of proc mount to use
+                          for the containers. The default is DefaultProcMount which
+                          uses the container runtime defaults for readonly paths and
+                          masked paths. This requires the ProcMountType feature flag
+                          to be enabled.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: Whether this container has a read-only root filesystem.
+                          Default is false.
+                        type: boolean
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set in
+                          PodSecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail to
+                          start the container if it does. If unset or false, no such
+                          validation will be performed. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if unspecified.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext
+                          and PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to the container.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies to
+                              the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies to
+                              the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies to
+                              the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies to
+                              the container.
+                            type: string
+                        type: object
+                      windowsOptions:
+                        description: The Windows specific settings applied to all containers.
+                          If unspecified, the options from the PodSecurityContext will
+                          be used. If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field. This field is alpha-level
+                              and is only honored by servers that enable the WindowsGMSA
+                              feature flag.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the GMSA
+                              credential spec to use. This field is alpha-level and
+                              is only honored by servers that enable the WindowsGMSA
+                              feature flag.
+                            type: string
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in PodSecurityContext.
+                              If set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence.
+                              This field is alpha-level and it is only honored by servers
+                              that enable the WindowsRunAsUserName feature flag.
+                            type: string
+                        type: object
+                    type: object
+                  serviceAccountName:
+                    description: memcached deployment ServiceAccountName, default is
+                      default
+                    type: string
+                  tolerations:
+                    description: memcached deployment tolerations, default is empty
+                    items:
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using the
+                        matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match. Empty
+                            means match all taint effects. When specified, allowed values
+                            are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to the
+                            value. Valid operators are Exists and Equal. Defaults to
+                            Equal. Exists is equivalent to wildcard for value, so that
+                            a pod can tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of time
+                            the toleration (which must be of effect NoExecute, otherwise
+                            this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do
+                            not evict). Zero and negative values will be treated as
+                            0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                required:
+                - name
+                type: object
+            type: object
+          status:
+            description: HealthServiceStatus defines the observed state of HealthService
+            properties:
+              healthCheckNodes:
+                description: HealthCheckNodes are the names of the Healch Service pods
+                items:
+                  type: string
+                type: array
+              memcachedNodes:
+                description: MemcachedNodes are the names of the memcached pods
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object     

--- a/deploy/crds/operator.ibm.com_mustgatherconfigs_crd.yaml
+++ b/deploy/crds/operator.ibm.com_mustgatherconfigs_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: mustgatherconfigs.operator.ibm.com
@@ -14,40 +14,39 @@ spec:
     plural: mustgatherconfigs
     singular: mustgatherconfig
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: MustGatherConfig is the Schema for the mustgatherconfigs API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: MustGatherConfigSpec defines the desired state of MustGatherConfig
-          properties:
-            gatherConfig:
-              description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-                Important: Run "operator-sdk generate k8s" to regenerate code after
-                modifying this file Add custom validation using kubebuilder tags:
-                https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
-              type: string
-          type: object
-        status:
-          description: MustGatherConfigStatus defines the observed state of MustGatherConfig
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
     served: true
     storage: true
+    subresources:
+      status: {}
+    schema:      
+      openAPIV3Schema:
+        description: MustGatherConfig is the Schema for the mustgatherconfigs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MustGatherConfigSpec defines the desired state of MustGatherConfig
+            properties:
+              gatherConfig:
+                description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                  Important: Run "operator-sdk generate k8s" to regenerate code after
+                  modifying this file Add custom validation using kubebuilder tags:
+                  https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+                type: string
+            type: object
+          status:
+            description: MustGatherConfigStatus defines the observed state of MustGatherConfig
+            type: object
+        type: object

--- a/deploy/crds/operator.ibm.com_mustgatherjobs_crd.yaml
+++ b/deploy/crds/operator.ibm.com_mustgatherjobs_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: mustgatherjobs.operator.ibm.com
@@ -14,63 +14,62 @@ spec:
     plural: mustgatherjobs
     singular: mustgatherjob
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: MustGatherJob is the Schema for the mustgatherjobs API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: MustGatherJobSpec defines the desired state of MustGatherJob
-          properties:
-            image:
-              description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-                Important: Run "operator-sdk generate k8s" to regenerate code after
-                modifying this file Add custom validation using kubebuilder tags:
-                https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
-                must gather image'
-              properties:
-                pullPolicy:
-                  description: image pull policy, default is IfNotPresent
-                  type: string
-                repository:
-                  description: image repository, default is empty
-                  type: string
-                tag:
-                  description: image tag, default is empty
-                  type: string
-              required:
-              - repository
-              - tag
-              type: object
-            mustgatherCommand:
-              description: must gather command, default is gather
-              type: string
-            mustgatherConfigName:
-              description: must gather config name, default is default
-              type: string
-            serviceAccountName:
-              description: must gather job ServiceAccountName, default is default
-              type: string
-          type: object
-        status:
-          description: MustGatherJobStatus defines the observed state of MustGatherJob
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
     served: true
     storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        description: MustGatherJob is the Schema for the mustgatherjobs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MustGatherJobSpec defines the desired state of MustGatherJob
+            properties:
+              image:
+                description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                  Important: Run "operator-sdk generate k8s" to regenerate code after
+                  modifying this file Add custom validation using kubebuilder tags:
+                  https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
+                  must gather image'
+                properties:
+                  pullPolicy:
+                    description: image pull policy, default is IfNotPresent
+                    type: string
+                  repository:
+                    description: image repository, default is empty
+                    type: string
+                  tag:
+                    description: image tag, default is empty
+                    type: string
+                required:
+                - repository
+                - tag
+                type: object
+              mustgatherCommand:
+                description: must gather command, default is gather
+                type: string
+              mustgatherConfigName:
+                description: must gather config name, default is default
+                type: string
+              serviceAccountName:
+                description: must gather job ServiceAccountName, default is default
+                type: string
+            type: object
+          status:
+            description: MustGatherJobStatus defines the observed state of MustGatherJob
+            type: object
+        type: object

--- a/deploy/crds/operator.ibm.com_mustgatherservices_crd.yaml
+++ b/deploy/crds/operator.ibm.com_mustgatherservices_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: mustgatherservices.operator.ibm.com
@@ -14,311 +14,310 @@ spec:
     plural: mustgatherservices
     singular: mustgatherservice
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: MustGatherService is the Schema for the mustgatherservices API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: MustGatherServiceSpec defines the desired state of MustGatherService
-          properties:
-            mustGather:
-              description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-                Important: Run "operator-sdk generate k8s" to regenerate code after
-                modifying this file Add custom validation using kubebuilder tags:
-                https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
-              properties:
-                command:
-                  description: MustGatherService startup command, default value is
-                    "/bin/must-gather-service -v 1"
-                  items:
-                    type: string
-                  type: array
-                hostNetwork:
-                  description: MustGatherService deployment hostnetwork, default is
-                    false
-                  type: boolean
-                image:
-                  description: deprecated, define image in operator.yaml
-                  properties:
-                    pullPolicy:
-                      description: image pull policy, default is IfNotPresent
-                      type: string
-                    repository:
-                      description: image repository, default is empty
-                      type: string
-                    tag:
-                      description: image tag, default is empty
-                      type: string
-                  required:
-                  - repository
-                  - tag
-                  type: object
-                name:
-                  description: MustGatherService deployment name
-                  type: string
-                nodeSelector:
-                  additionalProperties:
-                    type: string
-                  description: MustGatherService deployment node selector, default
-                    is empty
-                  type: object
-                replicas:
-                  description: MustGatherService pod replicas, default is 1
-                  format: int32
-                  type: integer
-                resources:
-                  description: resources defines the desired state of Resources
-                  properties:
-                    limits:
-                      properties:
-                        cpu:
-                          type: string
-                        memory:
-                          type: string
-                      type: object
-                    requests:
-                      properties:
-                        cpu:
-                          type: string
-                        memory:
-                          type: string
-                      type: object
-                  type: object
-                securityContext:
-                  description: MustGatherService deployment security context, default
-                    is empty
-                  properties:
-                    allowPrivilegeEscalation:
-                      description: 'AllowPrivilegeEscalation controls whether a process
-                        can gain more privileges than its parent process. This bool
-                        directly controls if the no_new_privs flag will be set on
-                        the container process. AllowPrivilegeEscalation is true always
-                        when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
-                      type: boolean
-                    capabilities:
-                      description: The capabilities to add/drop when running containers.
-                        Defaults to the default set of capabilities granted by the
-                        container runtime.
-                      properties:
-                        add:
-                          description: Added capabilities
-                          items:
-                            description: Capability represent POSIX capabilities type
-                            type: string
-                          type: array
-                        drop:
-                          description: Removed capabilities
-                          items:
-                            description: Capability represent POSIX capabilities type
-                            type: string
-                          type: array
-                      type: object
-                    privileged:
-                      description: Run container in privileged mode. Processes in
-                        privileged containers are essentially equivalent to root on
-                        the host. Defaults to false.
-                      type: boolean
-                    procMount:
-                      description: procMount denotes the type of proc mount to use
-                        for the containers. The default is DefaultProcMount which
-                        uses the container runtime defaults for readonly paths and
-                        masked paths. This requires the ProcMountType feature flag
-                        to be enabled.
-                      type: string
-                    readOnlyRootFilesystem:
-                      description: Whether this container has a read-only root filesystem.
-                        Default is false.
-                      type: boolean
-                    runAsGroup:
-                      description: The GID to run the entrypoint of the container
-                        process. Uses runtime default if unset. May also be set in
-                        PodSecurityContext.  If set in both SecurityContext and PodSecurityContext,
-                        the value specified in SecurityContext takes precedence.
-                      format: int64
-                      type: integer
-                    runAsNonRoot:
-                      description: Indicates that the container must run as a non-root
-                        user. If true, the Kubelet will validate the image at runtime
-                        to ensure that it does not run as UID 0 (root) and fail to
-                        start the container if it does. If unset or false, no such
-                        validation will be performed. May also be set in PodSecurityContext.  If
-                        set in both SecurityContext and PodSecurityContext, the value
-                        specified in SecurityContext takes precedence.
-                      type: boolean
-                    runAsUser:
-                      description: The UID to run the entrypoint of the container
-                        process. Defaults to user specified in image metadata if unspecified.
-                        May also be set in PodSecurityContext.  If set in both SecurityContext
-                        and PodSecurityContext, the value specified in SecurityContext
-                        takes precedence.
-                      format: int64
-                      type: integer
-                    seLinuxOptions:
-                      description: The SELinux context to be applied to the container.
-                        If unspecified, the container runtime will allocate a random
-                        SELinux context for each container.  May also be set in PodSecurityContext.  If
-                        set in both SecurityContext and PodSecurityContext, the value
-                        specified in SecurityContext takes precedence.
-                      properties:
-                        level:
-                          description: Level is SELinux level label that applies to
-                            the container.
-                          type: string
-                        role:
-                          description: Role is a SELinux role label that applies to
-                            the container.
-                          type: string
-                        type:
-                          description: Type is a SELinux type label that applies to
-                            the container.
-                          type: string
-                        user:
-                          description: User is a SELinux user label that applies to
-                            the container.
-                          type: string
-                      type: object
-                    windowsOptions:
-                      description: The Windows specific settings applied to all containers.
-                        If unspecified, the options from the PodSecurityContext will
-                        be used. If set in both SecurityContext and PodSecurityContext,
-                        the value specified in SecurityContext takes precedence.
-                      properties:
-                        gmsaCredentialSpec:
-                          description: GMSACredentialSpec is where the GMSA admission
-                            webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                            inlines the contents of the GMSA credential spec named
-                            by the GMSACredentialSpecName field. This field is alpha-level
-                            and is only honored by servers that enable the WindowsGMSA
-                            feature flag.
-                          type: string
-                        gmsaCredentialSpecName:
-                          description: GMSACredentialSpecName is the name of the GMSA
-                            credential spec to use. This field is alpha-level and
-                            is only honored by servers that enable the WindowsGMSA
-                            feature flag.
-                          type: string
-                        runAsUserName:
-                          description: The UserName in Windows to run the entrypoint
-                            of the container process. Defaults to the user specified
-                            in image metadata if unspecified. May also be set in PodSecurityContext.
-                            If set in both SecurityContext and PodSecurityContext,
-                            the value specified in SecurityContext takes precedence.
-                            This field is alpha-level and it is only honored by servers
-                            that enable the WindowsRunAsUserName feature flag.
-                          type: string
-                      type: object
-                  type: object
-                serviceAccountName:
-                  description: MustGatherService deployment ServiceAccountName, default
-                    is default
-                  type: string
-                tolerations:
-                  description: MustGatherService deployment tolerations, default is
-                    empty
-                  items:
-                    description: The pod this Toleration is attached to tolerates
-                      any taint that matches the triple <key,value,effect> using the
-                      matching operator <operator>.
-                    properties:
-                      effect:
-                        description: Effect indicates the taint effect to match. Empty
-                          means match all taint effects. When specified, allowed values
-                          are NoSchedule, PreferNoSchedule and NoExecute.
-                        type: string
-                      key:
-                        description: Key is the taint key that the toleration applies
-                          to. Empty means match all taint keys. If the key is empty,
-                          operator must be Exists; this combination means to match
-                          all values and all keys.
-                        type: string
-                      operator:
-                        description: Operator represents a key's relationship to the
-                          value. Valid operators are Exists and Equal. Defaults to
-                          Equal. Exists is equivalent to wildcard for value, so that
-                          a pod can tolerate all taints of a particular category.
-                        type: string
-                      tolerationSeconds:
-                        description: TolerationSeconds represents the period of time
-                          the toleration (which must be of effect NoExecute, otherwise
-                          this field is ignored) tolerates the taint. By default,
-                          it is not set, which means tolerate the taint forever (do
-                          not evict). Zero and negative values will be treated as
-                          0 (evict immediately) by the system.
-                        format: int64
-                        type: integer
-                      value:
-                        description: Value is the taint value the toleration matches
-                          to. If the operator is Exists, the value should be empty,
-                          otherwise just a regular string.
-                        type: string
-                    type: object
-                  type: array
-              required:
-              - name
-              type: object
-            persistentVolumeClaim:
-              description: persistentVolumeClaim defines the desired persistent volume
-                claim
-              properties:
-                name:
-                  description: MustGatherService pvc name
-                  type: string
-                resources:
-                  description: resources defines the request storage size
-                  properties:
-                    limits:
-                      additionalProperties:
-                        type: string
-                      description: 'Limits describes the maximum amount of compute
-                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                    requests:
-                      additionalProperties:
-                        type: string
-                      description: 'Requests describes the minimum amount of compute
-                        resources required. If Requests is omitted for a container,
-                        it defaults to Limits if that is explicitly specified, otherwise
-                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                  type: object
-                storageClassName:
-                  description: storageClassName defines the storageclass name, default
-                    is default storageclass in cluster
-                  type: string
-              required:
-              - name
-              type: object
-          type: object
-        status:
-          description: MustGatherServiceStatus defines the observed state of MustGatherService
-          properties:
-            mustGatherServiceNodes:
-              description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
-                of cluster Important: Run "operator-sdk generate k8s" to regenerate
-                code after modifying this file Add custom validation using kubebuilder
-                tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
-                MustGatherServiceNodes are the names of the MustGatherService pods'
-              items:
-                type: string
-              type: array
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
     served: true
     storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        description: MustGatherService is the Schema for the mustgatherservices API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MustGatherServiceSpec defines the desired state of MustGatherService
+            properties:
+              mustGather:
+                description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                  Important: Run "operator-sdk generate k8s" to regenerate code after
+                  modifying this file Add custom validation using kubebuilder tags:
+                  https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+                properties:
+                  command:
+                    description: MustGatherService startup command, default value is
+                      "/bin/must-gather-service -v 1"
+                    items:
+                      type: string
+                    type: array
+                  hostNetwork:
+                    description: MustGatherService deployment hostnetwork, default is
+                      false
+                    type: boolean
+                  image:
+                    description: deprecated, define image in operator.yaml
+                    properties:
+                      pullPolicy:
+                        description: image pull policy, default is IfNotPresent
+                        type: string
+                      repository:
+                        description: image repository, default is empty
+                        type: string
+                      tag:
+                        description: image tag, default is empty
+                        type: string
+                    required:
+                    - repository
+                    - tag
+                    type: object
+                  name:
+                    description: MustGatherService deployment name
+                    type: string
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: MustGatherService deployment node selector, default
+                      is empty
+                    type: object
+                  replicas:
+                    description: MustGatherService pod replicas, default is 1
+                    format: int32
+                    type: integer
+                  resources:
+                    description: resources defines the desired state of Resources
+                    properties:
+                      limits:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                        type: object
+                      requests:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                        type: object
+                    type: object
+                  securityContext:
+                    description: MustGatherService deployment security context, default
+                      is empty
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: 'AllowPrivilegeEscalation controls whether a process
+                          can gain more privileges than its parent process. This bool
+                          directly controls if the no_new_privs flag will be set on
+                          the container process. AllowPrivilegeEscalation is true always
+                          when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                        type: boolean
+                      capabilities:
+                        description: The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the
+                          container runtime.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities type
+                              type: string
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities type
+                              type: string
+                            type: array
+                        type: object
+                      privileged:
+                        description: Run container in privileged mode. Processes in
+                          privileged containers are essentially equivalent to root on
+                          the host. Defaults to false.
+                        type: boolean
+                      procMount:
+                        description: procMount denotes the type of proc mount to use
+                          for the containers. The default is DefaultProcMount which
+                          uses the container runtime defaults for readonly paths and
+                          masked paths. This requires the ProcMountType feature flag
+                          to be enabled.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: Whether this container has a read-only root filesystem.
+                          Default is false.
+                        type: boolean
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set in
+                          PodSecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail to
+                          start the container if it does. If unset or false, no such
+                          validation will be performed. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if unspecified.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext
+                          and PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to the container.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies to
+                              the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies to
+                              the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies to
+                              the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies to
+                              the container.
+                            type: string
+                        type: object
+                      windowsOptions:
+                        description: The Windows specific settings applied to all containers.
+                          If unspecified, the options from the PodSecurityContext will
+                          be used. If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field. This field is alpha-level
+                              and is only honored by servers that enable the WindowsGMSA
+                              feature flag.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the GMSA
+                              credential spec to use. This field is alpha-level and
+                              is only honored by servers that enable the WindowsGMSA
+                              feature flag.
+                            type: string
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in PodSecurityContext.
+                              If set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence.
+                              This field is alpha-level and it is only honored by servers
+                              that enable the WindowsRunAsUserName feature flag.
+                            type: string
+                        type: object
+                    type: object
+                  serviceAccountName:
+                    description: MustGatherService deployment ServiceAccountName, default
+                      is default
+                    type: string
+                  tolerations:
+                    description: MustGatherService deployment tolerations, default is
+                      empty
+                    items:
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using the
+                        matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match. Empty
+                            means match all taint effects. When specified, allowed values
+                            are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to the
+                            value. Valid operators are Exists and Equal. Defaults to
+                            Equal. Exists is equivalent to wildcard for value, so that
+                            a pod can tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of time
+                            the toleration (which must be of effect NoExecute, otherwise
+                            this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do
+                            not evict). Zero and negative values will be treated as
+                            0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                required:
+                - name
+                type: object
+              persistentVolumeClaim:
+                description: persistentVolumeClaim defines the desired persistent volume
+                  claim
+                properties:
+                  name:
+                    description: MustGatherService pvc name
+                    type: string
+                  resources:
+                    description: resources defines the request storage size
+                    properties:
+                      limits:
+                        additionalProperties:
+                          type: string
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          type: string
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                  storageClassName:
+                    description: storageClassName defines the storageclass name, default
+                      is default storageclass in cluster
+                    type: string
+                required:
+                - name
+                type: object
+            type: object
+          status:
+            description: MustGatherServiceStatus defines the observed state of MustGatherService
+            properties:
+              mustGatherServiceNodes:
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                  of cluster Important: Run "operator-sdk generate k8s" to regenerate
+                  code after modifying this file Add custom validation using kubebuilder
+                  tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
+                  MustGatherServiceNodes are the names of the MustGatherService pods'
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object          

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.11.0/clusterhealth.ibm.com_clusterservicestatuses_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.11.0/clusterhealth.ibm.com_clusterservicestatuses_crd.yaml
@@ -4,7 +4,7 @@
 # US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
 ###############################################################################
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clusterservicestatuses.clusterhealth.ibm.com
@@ -18,7 +18,40 @@ spec:
     - name: v1
       served: true
       storage: true
-  version: v1
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            status:
+              type: object
+              properties:
+                currentState:
+                  type: string
+                restartCount:
+                  type: integer
+                statusDependencies:
+                  type: array
+                  items: {
+                    type: string
+                  }
+                podFailureStatus:
+                  type: object
+      additionalPrinterColumns:
+      -
+        name: Service Name
+        type: string
+        description: The name of the service
+        jsonPath: .metadata.labels.clusterhealth\.ibm\.com/service-name
+      -
+        name: Service Version
+        type: string
+        description: The version of the service
+        jsonPath: .metadata.labels.clusterhealth\.ibm\.com/service-version
+      -
+        name: Status
+        type: string
+        description: The current status of the service
+        jsonPath: .status.currentState                        
   scope: Cluster
   names:
     kind: ClusterServiceStatus
@@ -26,35 +59,3 @@ spec:
     plural: clusterservicestatuses
     shortNames:
     - css
-  additionalPrinterColumns:
-  -
-    name: Service Name
-    type: string
-    description: The name of the service
-    JSONPath: .metadata.labels.clusterhealth\.ibm\.com/service-name
-  -
-    name: Service Version
-    type: string
-    description: The version of the service
-    JSONPath: .metadata.labels.clusterhealth\.ibm\.com/service-version
-  -
-    name: Status
-    type: string
-    description: The current status of the service
-    JSONPath: .status.currentState
-  validation:
-    openAPIV3Schema:
-      properties:
-        status:
-          properties:
-            currentState:
-              type: string
-            restartCount:
-              type: integer
-            statusDependencies:
-              type: array
-              items: {
-                type: string
-              }
-            podFailureStatus:
-              type: object

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.11.0/operator.ibm.com_healthservices_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.11.0/operator.ibm.com_healthservices_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: healthservices.operator.ibm.com
@@ -14,507 +14,506 @@ spec:
     plural: healthservices
     singular: healthservice
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: HealthService is the Schema for the healthservices API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: HealthServiceSpec defines the desired state of HealthService
-          properties:
-            healthService:
-              description: HealthService defines the desired state of HealthService.HealthService
-              properties:
-                cloudpakNameSetting:
-                  description: set labels/annotation name to get pod's cloudpakname
-                  type: string
-                configmapName:
-                  description: configmap which contains health srevice configuration
-                    files, deprecated
-                  type: string
-                dependsSetting:
-                  description: set labels/annotation name to get pod's dependencies
-                  type: string
-                hostNetwork:
-                  description: health srevice deployment hostnetwork, default is false
-                  type: boolean
-                image:
-                  description: deprecated, define image in operator.yaml
-                  properties:
-                    pullPolicy:
-                      description: image pull policy, default is IfNotPresent
-                      type: string
-                    repository:
-                      description: image repository, default is empty
-                      type: string
-                    tag:
-                      description: image tag, default is empty
-                      type: string
-                  required:
-                  - repository
-                  - tag
-                  type: object
-                name:
-                  description: health service deployment name
-                  type: string
-                nodeSelector:
-                  additionalProperties:
-                    type: string
-                  description: health srevice deployment node selector, default is
-                    empty
-                  type: object
-                replicas:
-                  description: health service pod replicas, default is 1
-                  format: int32
-                  type: integer
-                resources:
-                  description: resources defines the desired state of Resources
-                  properties:
-                    limits:
-                      properties:
-                        cpu:
-                          type: string
-                        memory:
-                          type: string
-                      type: object
-                    requests:
-                      properties:
-                        cpu:
-                          type: string
-                        memory:
-                          type: string
-                      type: object
-                  type: object
-                securityContext:
-                  description: memcached deployment security context, default is empty
-                  properties:
-                    allowPrivilegeEscalation:
-                      description: 'AllowPrivilegeEscalation controls whether a process
-                        can gain more privileges than its parent process. This bool
-                        directly controls if the no_new_privs flag will be set on
-                        the container process. AllowPrivilegeEscalation is true always
-                        when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
-                      type: boolean
-                    capabilities:
-                      description: The capabilities to add/drop when running containers.
-                        Defaults to the default set of capabilities granted by the
-                        container runtime.
-                      properties:
-                        add:
-                          description: Added capabilities
-                          items:
-                            description: Capability represent POSIX capabilities type
-                            type: string
-                          type: array
-                        drop:
-                          description: Removed capabilities
-                          items:
-                            description: Capability represent POSIX capabilities type
-                            type: string
-                          type: array
-                      type: object
-                    privileged:
-                      description: Run container in privileged mode. Processes in
-                        privileged containers are essentially equivalent to root on
-                        the host. Defaults to false.
-                      type: boolean
-                    procMount:
-                      description: procMount denotes the type of proc mount to use
-                        for the containers. The default is DefaultProcMount which
-                        uses the container runtime defaults for readonly paths and
-                        masked paths. This requires the ProcMountType feature flag
-                        to be enabled.
-                      type: string
-                    readOnlyRootFilesystem:
-                      description: Whether this container has a read-only root filesystem.
-                        Default is false.
-                      type: boolean
-                    runAsGroup:
-                      description: The GID to run the entrypoint of the container
-                        process. Uses runtime default if unset. May also be set in
-                        PodSecurityContext.  If set in both SecurityContext and PodSecurityContext,
-                        the value specified in SecurityContext takes precedence.
-                      format: int64
-                      type: integer
-                    runAsNonRoot:
-                      description: Indicates that the container must run as a non-root
-                        user. If true, the Kubelet will validate the image at runtime
-                        to ensure that it does not run as UID 0 (root) and fail to
-                        start the container if it does. If unset or false, no such
-                        validation will be performed. May also be set in PodSecurityContext.  If
-                        set in both SecurityContext and PodSecurityContext, the value
-                        specified in SecurityContext takes precedence.
-                      type: boolean
-                    runAsUser:
-                      description: The UID to run the entrypoint of the container
-                        process. Defaults to user specified in image metadata if unspecified.
-                        May also be set in PodSecurityContext.  If set in both SecurityContext
-                        and PodSecurityContext, the value specified in SecurityContext
-                        takes precedence.
-                      format: int64
-                      type: integer
-                    seLinuxOptions:
-                      description: The SELinux context to be applied to the container.
-                        If unspecified, the container runtime will allocate a random
-                        SELinux context for each container.  May also be set in PodSecurityContext.  If
-                        set in both SecurityContext and PodSecurityContext, the value
-                        specified in SecurityContext takes precedence.
-                      properties:
-                        level:
-                          description: Level is SELinux level label that applies to
-                            the container.
-                          type: string
-                        role:
-                          description: Role is a SELinux role label that applies to
-                            the container.
-                          type: string
-                        type:
-                          description: Type is a SELinux type label that applies to
-                            the container.
-                          type: string
-                        user:
-                          description: User is a SELinux user label that applies to
-                            the container.
-                          type: string
-                      type: object
-                    windowsOptions:
-                      description: The Windows specific settings applied to all containers.
-                        If unspecified, the options from the PodSecurityContext will
-                        be used. If set in both SecurityContext and PodSecurityContext,
-                        the value specified in SecurityContext takes precedence.
-                      properties:
-                        gmsaCredentialSpec:
-                          description: GMSACredentialSpec is where the GMSA admission
-                            webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                            inlines the contents of the GMSA credential spec named
-                            by the GMSACredentialSpecName field. This field is alpha-level
-                            and is only honored by servers that enable the WindowsGMSA
-                            feature flag.
-                          type: string
-                        gmsaCredentialSpecName:
-                          description: GMSACredentialSpecName is the name of the GMSA
-                            credential spec to use. This field is alpha-level and
-                            is only honored by servers that enable the WindowsGMSA
-                            feature flag.
-                          type: string
-                        runAsUserName:
-                          description: The UserName in Windows to run the entrypoint
-                            of the container process. Defaults to the user specified
-                            in image metadata if unspecified. May also be set in PodSecurityContext.
-                            If set in both SecurityContext and PodSecurityContext,
-                            the value specified in SecurityContext takes precedence.
-                            This field is alpha-level and it is only honored by servers
-                            that enable the WindowsRunAsUserName feature flag.
-                          type: string
-                      type: object
-                  type: object
-                serviceAccountName:
-                  description: health service deployment ServiceAccountName, default
-                    is default
-                  type: string
-                serviceNameSetting:
-                  description: set labels/annotation name to get pod's servicename
-                  type: string
-                tolerations:
-                  description: health srevice deployment tolerations, default is empty
-                  items:
-                    description: The pod this Toleration is attached to tolerates
-                      any taint that matches the triple <key,value,effect> using the
-                      matching operator <operator>.
-                    properties:
-                      effect:
-                        description: Effect indicates the taint effect to match. Empty
-                          means match all taint effects. When specified, allowed values
-                          are NoSchedule, PreferNoSchedule and NoExecute.
-                        type: string
-                      key:
-                        description: Key is the taint key that the toleration applies
-                          to. Empty means match all taint keys. If the key is empty,
-                          operator must be Exists; this combination means to match
-                          all values and all keys.
-                        type: string
-                      operator:
-                        description: Operator represents a key's relationship to the
-                          value. Valid operators are Exists and Equal. Defaults to
-                          Equal. Exists is equivalent to wildcard for value, so that
-                          a pod can tolerate all taints of a particular category.
-                        type: string
-                      tolerationSeconds:
-                        description: TolerationSeconds represents the period of time
-                          the toleration (which must be of effect NoExecute, otherwise
-                          this field is ignored) tolerates the taint. By default,
-                          it is not set, which means tolerate the taint forever (do
-                          not evict). Zero and negative values will be treated as
-                          0 (evict immediately) by the system.
-                        format: int64
-                        type: integer
-                      value:
-                        description: Value is the taint value the toleration matches
-                          to. If the operator is Exists, the value should be empty,
-                          otherwise just a regular string.
-                        type: string
-                    type: object
-                  type: array
-              required:
-              - configmapName
-              - name
-              type: object
-            memcached:
-              description: Memcached defines the desired state of HealthService.Memcached
-              properties:
-                command:
-                  description: memcached startup command, default value is "memcached
-                    -m 64 -o modern -v"
-                  items:
-                    type: string
-                  type: array
-                image:
-                  description: deprecated, define image in operator.yaml
-                  properties:
-                    pullPolicy:
-                      description: image pull policy, default is IfNotPresent
-                      type: string
-                    repository:
-                      description: image repository, default is empty
-                      type: string
-                    tag:
-                      description: image tag, default is empty
-                      type: string
-                  required:
-                  - repository
-                  - tag
-                  type: object
-                name:
-                  description: memcached deployment name
-                  type: string
-                nodeSelector:
-                  additionalProperties:
-                    type: string
-                  description: memcached deployment node selector, default is empty
-                  type: object
-                replicas:
-                  description: memcached pod replicas, default is 1
-                  format: int32
-                  type: integer
-                resources:
-                  description: resources defines the desired state of Resources
-                  properties:
-                    limits:
-                      properties:
-                        cpu:
-                          type: string
-                        memory:
-                          type: string
-                      type: object
-                    requests:
-                      properties:
-                        cpu:
-                          type: string
-                        memory:
-                          type: string
-                      type: object
-                  type: object
-                securityContext:
-                  description: memcached deployment security context, default is empty
-                  properties:
-                    allowPrivilegeEscalation:
-                      description: 'AllowPrivilegeEscalation controls whether a process
-                        can gain more privileges than its parent process. This bool
-                        directly controls if the no_new_privs flag will be set on
-                        the container process. AllowPrivilegeEscalation is true always
-                        when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
-                      type: boolean
-                    capabilities:
-                      description: The capabilities to add/drop when running containers.
-                        Defaults to the default set of capabilities granted by the
-                        container runtime.
-                      properties:
-                        add:
-                          description: Added capabilities
-                          items:
-                            description: Capability represent POSIX capabilities type
-                            type: string
-                          type: array
-                        drop:
-                          description: Removed capabilities
-                          items:
-                            description: Capability represent POSIX capabilities type
-                            type: string
-                          type: array
-                      type: object
-                    privileged:
-                      description: Run container in privileged mode. Processes in
-                        privileged containers are essentially equivalent to root on
-                        the host. Defaults to false.
-                      type: boolean
-                    procMount:
-                      description: procMount denotes the type of proc mount to use
-                        for the containers. The default is DefaultProcMount which
-                        uses the container runtime defaults for readonly paths and
-                        masked paths. This requires the ProcMountType feature flag
-                        to be enabled.
-                      type: string
-                    readOnlyRootFilesystem:
-                      description: Whether this container has a read-only root filesystem.
-                        Default is false.
-                      type: boolean
-                    runAsGroup:
-                      description: The GID to run the entrypoint of the container
-                        process. Uses runtime default if unset. May also be set in
-                        PodSecurityContext.  If set in both SecurityContext and PodSecurityContext,
-                        the value specified in SecurityContext takes precedence.
-                      format: int64
-                      type: integer
-                    runAsNonRoot:
-                      description: Indicates that the container must run as a non-root
-                        user. If true, the Kubelet will validate the image at runtime
-                        to ensure that it does not run as UID 0 (root) and fail to
-                        start the container if it does. If unset or false, no such
-                        validation will be performed. May also be set in PodSecurityContext.  If
-                        set in both SecurityContext and PodSecurityContext, the value
-                        specified in SecurityContext takes precedence.
-                      type: boolean
-                    runAsUser:
-                      description: The UID to run the entrypoint of the container
-                        process. Defaults to user specified in image metadata if unspecified.
-                        May also be set in PodSecurityContext.  If set in both SecurityContext
-                        and PodSecurityContext, the value specified in SecurityContext
-                        takes precedence.
-                      format: int64
-                      type: integer
-                    seLinuxOptions:
-                      description: The SELinux context to be applied to the container.
-                        If unspecified, the container runtime will allocate a random
-                        SELinux context for each container.  May also be set in PodSecurityContext.  If
-                        set in both SecurityContext and PodSecurityContext, the value
-                        specified in SecurityContext takes precedence.
-                      properties:
-                        level:
-                          description: Level is SELinux level label that applies to
-                            the container.
-                          type: string
-                        role:
-                          description: Role is a SELinux role label that applies to
-                            the container.
-                          type: string
-                        type:
-                          description: Type is a SELinux type label that applies to
-                            the container.
-                          type: string
-                        user:
-                          description: User is a SELinux user label that applies to
-                            the container.
-                          type: string
-                      type: object
-                    windowsOptions:
-                      description: The Windows specific settings applied to all containers.
-                        If unspecified, the options from the PodSecurityContext will
-                        be used. If set in both SecurityContext and PodSecurityContext,
-                        the value specified in SecurityContext takes precedence.
-                      properties:
-                        gmsaCredentialSpec:
-                          description: GMSACredentialSpec is where the GMSA admission
-                            webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                            inlines the contents of the GMSA credential spec named
-                            by the GMSACredentialSpecName field. This field is alpha-level
-                            and is only honored by servers that enable the WindowsGMSA
-                            feature flag.
-                          type: string
-                        gmsaCredentialSpecName:
-                          description: GMSACredentialSpecName is the name of the GMSA
-                            credential spec to use. This field is alpha-level and
-                            is only honored by servers that enable the WindowsGMSA
-                            feature flag.
-                          type: string
-                        runAsUserName:
-                          description: The UserName in Windows to run the entrypoint
-                            of the container process. Defaults to the user specified
-                            in image metadata if unspecified. May also be set in PodSecurityContext.
-                            If set in both SecurityContext and PodSecurityContext,
-                            the value specified in SecurityContext takes precedence.
-                            This field is alpha-level and it is only honored by servers
-                            that enable the WindowsRunAsUserName feature flag.
-                          type: string
-                      type: object
-                  type: object
-                serviceAccountName:
-                  description: memcached deployment ServiceAccountName, default is
-                    default
-                  type: string
-                tolerations:
-                  description: memcached deployment tolerations, default is empty
-                  items:
-                    description: The pod this Toleration is attached to tolerates
-                      any taint that matches the triple <key,value,effect> using the
-                      matching operator <operator>.
-                    properties:
-                      effect:
-                        description: Effect indicates the taint effect to match. Empty
-                          means match all taint effects. When specified, allowed values
-                          are NoSchedule, PreferNoSchedule and NoExecute.
-                        type: string
-                      key:
-                        description: Key is the taint key that the toleration applies
-                          to. Empty means match all taint keys. If the key is empty,
-                          operator must be Exists; this combination means to match
-                          all values and all keys.
-                        type: string
-                      operator:
-                        description: Operator represents a key's relationship to the
-                          value. Valid operators are Exists and Equal. Defaults to
-                          Equal. Exists is equivalent to wildcard for value, so that
-                          a pod can tolerate all taints of a particular category.
-                        type: string
-                      tolerationSeconds:
-                        description: TolerationSeconds represents the period of time
-                          the toleration (which must be of effect NoExecute, otherwise
-                          this field is ignored) tolerates the taint. By default,
-                          it is not set, which means tolerate the taint forever (do
-                          not evict). Zero and negative values will be treated as
-                          0 (evict immediately) by the system.
-                        format: int64
-                        type: integer
-                      value:
-                        description: Value is the taint value the toleration matches
-                          to. If the operator is Exists, the value should be empty,
-                          otherwise just a regular string.
-                        type: string
-                    type: object
-                  type: array
-              required:
-              - name
-              type: object
-          type: object
-        status:
-          description: HealthServiceStatus defines the observed state of HealthService
-          properties:
-            healthCheckNodes:
-              description: HealthCheckNodes are the names of the Healch Service pods
-              items:
-                type: string
-              type: array
-            memcachedNodes:
-              description: MemcachedNodes are the names of the memcached pods
-              items:
-                type: string
-              type: array
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
     served: true
     storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        description: HealthService is the Schema for the healthservices API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HealthServiceSpec defines the desired state of HealthService
+            properties:
+              healthService:
+                description: HealthService defines the desired state of HealthService.HealthService
+                properties:
+                  cloudpakNameSetting:
+                    description: set labels/annotation name to get pod's cloudpakname
+                    type: string
+                  configmapName:
+                    description: configmap which contains health srevice configuration
+                      files, deprecated
+                    type: string
+                  dependsSetting:
+                    description: set labels/annotation name to get pod's dependencies
+                    type: string
+                  hostNetwork:
+                    description: health srevice deployment hostnetwork, default is false
+                    type: boolean
+                  image:
+                    description: deprecated, define image in operator.yaml
+                    properties:
+                      pullPolicy:
+                        description: image pull policy, default is IfNotPresent
+                        type: string
+                      repository:
+                        description: image repository, default is empty
+                        type: string
+                      tag:
+                        description: image tag, default is empty
+                        type: string
+                    required:
+                    - repository
+                    - tag
+                    type: object
+                  name:
+                    description: health service deployment name
+                    type: string
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: health srevice deployment node selector, default is
+                      empty
+                    type: object
+                  replicas:
+                    description: health service pod replicas, default is 1
+                    format: int32
+                    type: integer
+                  resources:
+                    description: resources defines the desired state of Resources
+                    properties:
+                      limits:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                        type: object
+                      requests:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                        type: object
+                    type: object
+                  securityContext:
+                    description: memcached deployment security context, default is empty
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: 'AllowPrivilegeEscalation controls whether a process
+                          can gain more privileges than its parent process. This bool
+                          directly controls if the no_new_privs flag will be set on
+                          the container process. AllowPrivilegeEscalation is true always
+                          when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                        type: boolean
+                      capabilities:
+                        description: The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the
+                          container runtime.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities type
+                              type: string
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities type
+                              type: string
+                            type: array
+                        type: object
+                      privileged:
+                        description: Run container in privileged mode. Processes in
+                          privileged containers are essentially equivalent to root on
+                          the host. Defaults to false.
+                        type: boolean
+                      procMount:
+                        description: procMount denotes the type of proc mount to use
+                          for the containers. The default is DefaultProcMount which
+                          uses the container runtime defaults for readonly paths and
+                          masked paths. This requires the ProcMountType feature flag
+                          to be enabled.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: Whether this container has a read-only root filesystem.
+                          Default is false.
+                        type: boolean
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set in
+                          PodSecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail to
+                          start the container if it does. If unset or false, no such
+                          validation will be performed. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if unspecified.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext
+                          and PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to the container.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies to
+                              the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies to
+                              the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies to
+                              the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies to
+                              the container.
+                            type: string
+                        type: object
+                      windowsOptions:
+                        description: The Windows specific settings applied to all containers.
+                          If unspecified, the options from the PodSecurityContext will
+                          be used. If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field. This field is alpha-level
+                              and is only honored by servers that enable the WindowsGMSA
+                              feature flag.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the GMSA
+                              credential spec to use. This field is alpha-level and
+                              is only honored by servers that enable the WindowsGMSA
+                              feature flag.
+                            type: string
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in PodSecurityContext.
+                              If set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence.
+                              This field is alpha-level and it is only honored by servers
+                              that enable the WindowsRunAsUserName feature flag.
+                            type: string
+                        type: object
+                    type: object
+                  serviceAccountName:
+                    description: health service deployment ServiceAccountName, default
+                      is default
+                    type: string
+                  serviceNameSetting:
+                    description: set labels/annotation name to get pod's servicename
+                    type: string
+                  tolerations:
+                    description: health srevice deployment tolerations, default is empty
+                    items:
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using the
+                        matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match. Empty
+                            means match all taint effects. When specified, allowed values
+                            are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to the
+                            value. Valid operators are Exists and Equal. Defaults to
+                            Equal. Exists is equivalent to wildcard for value, so that
+                            a pod can tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of time
+                            the toleration (which must be of effect NoExecute, otherwise
+                            this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do
+                            not evict). Zero and negative values will be treated as
+                            0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                required:
+                - configmapName
+                - name
+                type: object
+              memcached:
+                description: Memcached defines the desired state of HealthService.Memcached
+                properties:
+                  command:
+                    description: memcached startup command, default value is "memcached
+                      -m 64 -o modern -v"
+                    items:
+                      type: string
+                    type: array
+                  image:
+                    description: deprecated, define image in operator.yaml
+                    properties:
+                      pullPolicy:
+                        description: image pull policy, default is IfNotPresent
+                        type: string
+                      repository:
+                        description: image repository, default is empty
+                        type: string
+                      tag:
+                        description: image tag, default is empty
+                        type: string
+                    required:
+                    - repository
+                    - tag
+                    type: object
+                  name:
+                    description: memcached deployment name
+                    type: string
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: memcached deployment node selector, default is empty
+                    type: object
+                  replicas:
+                    description: memcached pod replicas, default is 1
+                    format: int32
+                    type: integer
+                  resources:
+                    description: resources defines the desired state of Resources
+                    properties:
+                      limits:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                        type: object
+                      requests:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                        type: object
+                    type: object
+                  securityContext:
+                    description: memcached deployment security context, default is empty
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: 'AllowPrivilegeEscalation controls whether a process
+                          can gain more privileges than its parent process. This bool
+                          directly controls if the no_new_privs flag will be set on
+                          the container process. AllowPrivilegeEscalation is true always
+                          when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                        type: boolean
+                      capabilities:
+                        description: The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the
+                          container runtime.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities type
+                              type: string
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities type
+                              type: string
+                            type: array
+                        type: object
+                      privileged:
+                        description: Run container in privileged mode. Processes in
+                          privileged containers are essentially equivalent to root on
+                          the host. Defaults to false.
+                        type: boolean
+                      procMount:
+                        description: procMount denotes the type of proc mount to use
+                          for the containers. The default is DefaultProcMount which
+                          uses the container runtime defaults for readonly paths and
+                          masked paths. This requires the ProcMountType feature flag
+                          to be enabled.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: Whether this container has a read-only root filesystem.
+                          Default is false.
+                        type: boolean
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set in
+                          PodSecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail to
+                          start the container if it does. If unset or false, no such
+                          validation will be performed. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if unspecified.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext
+                          and PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to the container.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies to
+                              the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies to
+                              the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies to
+                              the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies to
+                              the container.
+                            type: string
+                        type: object
+                      windowsOptions:
+                        description: The Windows specific settings applied to all containers.
+                          If unspecified, the options from the PodSecurityContext will
+                          be used. If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field. This field is alpha-level
+                              and is only honored by servers that enable the WindowsGMSA
+                              feature flag.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the GMSA
+                              credential spec to use. This field is alpha-level and
+                              is only honored by servers that enable the WindowsGMSA
+                              feature flag.
+                            type: string
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in PodSecurityContext.
+                              If set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence.
+                              This field is alpha-level and it is only honored by servers
+                              that enable the WindowsRunAsUserName feature flag.
+                            type: string
+                        type: object
+                    type: object
+                  serviceAccountName:
+                    description: memcached deployment ServiceAccountName, default is
+                      default
+                    type: string
+                  tolerations:
+                    description: memcached deployment tolerations, default is empty
+                    items:
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using the
+                        matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match. Empty
+                            means match all taint effects. When specified, allowed values
+                            are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to the
+                            value. Valid operators are Exists and Equal. Defaults to
+                            Equal. Exists is equivalent to wildcard for value, so that
+                            a pod can tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of time
+                            the toleration (which must be of effect NoExecute, otherwise
+                            this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do
+                            not evict). Zero and negative values will be treated as
+                            0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                required:
+                - name
+                type: object
+            type: object
+          status:
+            description: HealthServiceStatus defines the observed state of HealthService
+            properties:
+              healthCheckNodes:
+                description: HealthCheckNodes are the names of the Healch Service pods
+                items:
+                  type: string
+                type: array
+              memcachedNodes:
+                description: MemcachedNodes are the names of the memcached pods
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object     

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.11.0/operator.ibm.com_mustgatherconfigs_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.11.0/operator.ibm.com_mustgatherconfigs_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: mustgatherconfigs.operator.ibm.com
@@ -14,40 +14,39 @@ spec:
     plural: mustgatherconfigs
     singular: mustgatherconfig
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: MustGatherConfig is the Schema for the mustgatherconfigs API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: MustGatherConfigSpec defines the desired state of MustGatherConfig
-          properties:
-            gatherConfig:
-              description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-                Important: Run "operator-sdk generate k8s" to regenerate code after
-                modifying this file Add custom validation using kubebuilder tags:
-                https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
-              type: string
-          type: object
-        status:
-          description: MustGatherConfigStatus defines the observed state of MustGatherConfig
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
     served: true
     storage: true
+    subresources:
+      status: {}
+    schema:      
+      openAPIV3Schema:
+        description: MustGatherConfig is the Schema for the mustgatherconfigs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MustGatherConfigSpec defines the desired state of MustGatherConfig
+            properties:
+              gatherConfig:
+                description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                  Important: Run "operator-sdk generate k8s" to regenerate code after
+                  modifying this file Add custom validation using kubebuilder tags:
+                  https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+                type: string
+            type: object
+          status:
+            description: MustGatherConfigStatus defines the observed state of MustGatherConfig
+            type: object
+        type: object

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.11.0/operator.ibm.com_mustgatherjobs_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.11.0/operator.ibm.com_mustgatherjobs_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: mustgatherjobs.operator.ibm.com
@@ -14,63 +14,62 @@ spec:
     plural: mustgatherjobs
     singular: mustgatherjob
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: MustGatherJob is the Schema for the mustgatherjobs API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: MustGatherJobSpec defines the desired state of MustGatherJob
-          properties:
-            image:
-              description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-                Important: Run "operator-sdk generate k8s" to regenerate code after
-                modifying this file Add custom validation using kubebuilder tags:
-                https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
-                must gather image'
-              properties:
-                pullPolicy:
-                  description: image pull policy, default is IfNotPresent
-                  type: string
-                repository:
-                  description: image repository, default is empty
-                  type: string
-                tag:
-                  description: image tag, default is empty
-                  type: string
-              required:
-              - repository
-              - tag
-              type: object
-            mustgatherCommand:
-              description: must gather command, default is gather
-              type: string
-            mustgatherConfigName:
-              description: must gather config name, default is default
-              type: string
-            serviceAccountName:
-              description: must gather job ServiceAccountName, default is default
-              type: string
-          type: object
-        status:
-          description: MustGatherJobStatus defines the observed state of MustGatherJob
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
     served: true
     storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        description: MustGatherJob is the Schema for the mustgatherjobs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MustGatherJobSpec defines the desired state of MustGatherJob
+            properties:
+              image:
+                description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                  Important: Run "operator-sdk generate k8s" to regenerate code after
+                  modifying this file Add custom validation using kubebuilder tags:
+                  https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
+                  must gather image'
+                properties:
+                  pullPolicy:
+                    description: image pull policy, default is IfNotPresent
+                    type: string
+                  repository:
+                    description: image repository, default is empty
+                    type: string
+                  tag:
+                    description: image tag, default is empty
+                    type: string
+                required:
+                - repository
+                - tag
+                type: object
+              mustgatherCommand:
+                description: must gather command, default is gather
+                type: string
+              mustgatherConfigName:
+                description: must gather config name, default is default
+                type: string
+              serviceAccountName:
+                description: must gather job ServiceAccountName, default is default
+                type: string
+            type: object
+          status:
+            description: MustGatherJobStatus defines the observed state of MustGatherJob
+            type: object
+        type: object

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.11.0/operator.ibm.com_mustgatherservices_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.11.0/operator.ibm.com_mustgatherservices_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: mustgatherservices.operator.ibm.com
@@ -14,311 +14,310 @@ spec:
     plural: mustgatherservices
     singular: mustgatherservice
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: MustGatherService is the Schema for the mustgatherservices API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: MustGatherServiceSpec defines the desired state of MustGatherService
-          properties:
-            mustGather:
-              description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-                Important: Run "operator-sdk generate k8s" to regenerate code after
-                modifying this file Add custom validation using kubebuilder tags:
-                https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
-              properties:
-                command:
-                  description: MustGatherService startup command, default value is
-                    "/bin/must-gather-service -v 1"
-                  items:
-                    type: string
-                  type: array
-                hostNetwork:
-                  description: MustGatherService deployment hostnetwork, default is
-                    false
-                  type: boolean
-                image:
-                  description: deprecated, define image in operator.yaml
-                  properties:
-                    pullPolicy:
-                      description: image pull policy, default is IfNotPresent
-                      type: string
-                    repository:
-                      description: image repository, default is empty
-                      type: string
-                    tag:
-                      description: image tag, default is empty
-                      type: string
-                  required:
-                  - repository
-                  - tag
-                  type: object
-                name:
-                  description: MustGatherService deployment name
-                  type: string
-                nodeSelector:
-                  additionalProperties:
-                    type: string
-                  description: MustGatherService deployment node selector, default
-                    is empty
-                  type: object
-                replicas:
-                  description: MustGatherService pod replicas, default is 1
-                  format: int32
-                  type: integer
-                resources:
-                  description: resources defines the desired state of Resources
-                  properties:
-                    limits:
-                      properties:
-                        cpu:
-                          type: string
-                        memory:
-                          type: string
-                      type: object
-                    requests:
-                      properties:
-                        cpu:
-                          type: string
-                        memory:
-                          type: string
-                      type: object
-                  type: object
-                securityContext:
-                  description: MustGatherService deployment security context, default
-                    is empty
-                  properties:
-                    allowPrivilegeEscalation:
-                      description: 'AllowPrivilegeEscalation controls whether a process
-                        can gain more privileges than its parent process. This bool
-                        directly controls if the no_new_privs flag will be set on
-                        the container process. AllowPrivilegeEscalation is true always
-                        when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
-                      type: boolean
-                    capabilities:
-                      description: The capabilities to add/drop when running containers.
-                        Defaults to the default set of capabilities granted by the
-                        container runtime.
-                      properties:
-                        add:
-                          description: Added capabilities
-                          items:
-                            description: Capability represent POSIX capabilities type
-                            type: string
-                          type: array
-                        drop:
-                          description: Removed capabilities
-                          items:
-                            description: Capability represent POSIX capabilities type
-                            type: string
-                          type: array
-                      type: object
-                    privileged:
-                      description: Run container in privileged mode. Processes in
-                        privileged containers are essentially equivalent to root on
-                        the host. Defaults to false.
-                      type: boolean
-                    procMount:
-                      description: procMount denotes the type of proc mount to use
-                        for the containers. The default is DefaultProcMount which
-                        uses the container runtime defaults for readonly paths and
-                        masked paths. This requires the ProcMountType feature flag
-                        to be enabled.
-                      type: string
-                    readOnlyRootFilesystem:
-                      description: Whether this container has a read-only root filesystem.
-                        Default is false.
-                      type: boolean
-                    runAsGroup:
-                      description: The GID to run the entrypoint of the container
-                        process. Uses runtime default if unset. May also be set in
-                        PodSecurityContext.  If set in both SecurityContext and PodSecurityContext,
-                        the value specified in SecurityContext takes precedence.
-                      format: int64
-                      type: integer
-                    runAsNonRoot:
-                      description: Indicates that the container must run as a non-root
-                        user. If true, the Kubelet will validate the image at runtime
-                        to ensure that it does not run as UID 0 (root) and fail to
-                        start the container if it does. If unset or false, no such
-                        validation will be performed. May also be set in PodSecurityContext.  If
-                        set in both SecurityContext and PodSecurityContext, the value
-                        specified in SecurityContext takes precedence.
-                      type: boolean
-                    runAsUser:
-                      description: The UID to run the entrypoint of the container
-                        process. Defaults to user specified in image metadata if unspecified.
-                        May also be set in PodSecurityContext.  If set in both SecurityContext
-                        and PodSecurityContext, the value specified in SecurityContext
-                        takes precedence.
-                      format: int64
-                      type: integer
-                    seLinuxOptions:
-                      description: The SELinux context to be applied to the container.
-                        If unspecified, the container runtime will allocate a random
-                        SELinux context for each container.  May also be set in PodSecurityContext.  If
-                        set in both SecurityContext and PodSecurityContext, the value
-                        specified in SecurityContext takes precedence.
-                      properties:
-                        level:
-                          description: Level is SELinux level label that applies to
-                            the container.
-                          type: string
-                        role:
-                          description: Role is a SELinux role label that applies to
-                            the container.
-                          type: string
-                        type:
-                          description: Type is a SELinux type label that applies to
-                            the container.
-                          type: string
-                        user:
-                          description: User is a SELinux user label that applies to
-                            the container.
-                          type: string
-                      type: object
-                    windowsOptions:
-                      description: The Windows specific settings applied to all containers.
-                        If unspecified, the options from the PodSecurityContext will
-                        be used. If set in both SecurityContext and PodSecurityContext,
-                        the value specified in SecurityContext takes precedence.
-                      properties:
-                        gmsaCredentialSpec:
-                          description: GMSACredentialSpec is where the GMSA admission
-                            webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                            inlines the contents of the GMSA credential spec named
-                            by the GMSACredentialSpecName field. This field is alpha-level
-                            and is only honored by servers that enable the WindowsGMSA
-                            feature flag.
-                          type: string
-                        gmsaCredentialSpecName:
-                          description: GMSACredentialSpecName is the name of the GMSA
-                            credential spec to use. This field is alpha-level and
-                            is only honored by servers that enable the WindowsGMSA
-                            feature flag.
-                          type: string
-                        runAsUserName:
-                          description: The UserName in Windows to run the entrypoint
-                            of the container process. Defaults to the user specified
-                            in image metadata if unspecified. May also be set in PodSecurityContext.
-                            If set in both SecurityContext and PodSecurityContext,
-                            the value specified in SecurityContext takes precedence.
-                            This field is alpha-level and it is only honored by servers
-                            that enable the WindowsRunAsUserName feature flag.
-                          type: string
-                      type: object
-                  type: object
-                serviceAccountName:
-                  description: MustGatherService deployment ServiceAccountName, default
-                    is default
-                  type: string
-                tolerations:
-                  description: MustGatherService deployment tolerations, default is
-                    empty
-                  items:
-                    description: The pod this Toleration is attached to tolerates
-                      any taint that matches the triple <key,value,effect> using the
-                      matching operator <operator>.
-                    properties:
-                      effect:
-                        description: Effect indicates the taint effect to match. Empty
-                          means match all taint effects. When specified, allowed values
-                          are NoSchedule, PreferNoSchedule and NoExecute.
-                        type: string
-                      key:
-                        description: Key is the taint key that the toleration applies
-                          to. Empty means match all taint keys. If the key is empty,
-                          operator must be Exists; this combination means to match
-                          all values and all keys.
-                        type: string
-                      operator:
-                        description: Operator represents a key's relationship to the
-                          value. Valid operators are Exists and Equal. Defaults to
-                          Equal. Exists is equivalent to wildcard for value, so that
-                          a pod can tolerate all taints of a particular category.
-                        type: string
-                      tolerationSeconds:
-                        description: TolerationSeconds represents the period of time
-                          the toleration (which must be of effect NoExecute, otherwise
-                          this field is ignored) tolerates the taint. By default,
-                          it is not set, which means tolerate the taint forever (do
-                          not evict). Zero and negative values will be treated as
-                          0 (evict immediately) by the system.
-                        format: int64
-                        type: integer
-                      value:
-                        description: Value is the taint value the toleration matches
-                          to. If the operator is Exists, the value should be empty,
-                          otherwise just a regular string.
-                        type: string
-                    type: object
-                  type: array
-              required:
-              - name
-              type: object
-            persistentVolumeClaim:
-              description: persistentVolumeClaim defines the desired persistent volume
-                claim
-              properties:
-                name:
-                  description: MustGatherService pvc name
-                  type: string
-                resources:
-                  description: resources defines the request storage size
-                  properties:
-                    limits:
-                      additionalProperties:
-                        type: string
-                      description: 'Limits describes the maximum amount of compute
-                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                    requests:
-                      additionalProperties:
-                        type: string
-                      description: 'Requests describes the minimum amount of compute
-                        resources required. If Requests is omitted for a container,
-                        it defaults to Limits if that is explicitly specified, otherwise
-                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                  type: object
-                storageClassName:
-                  description: storageClassName defines the storageclass name, default
-                    is default storageclass in cluster
-                  type: string
-              required:
-              - name
-              type: object
-          type: object
-        status:
-          description: MustGatherServiceStatus defines the observed state of MustGatherService
-          properties:
-            mustGatherServiceNodes:
-              description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
-                of cluster Important: Run "operator-sdk generate k8s" to regenerate
-                code after modifying this file Add custom validation using kubebuilder
-                tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
-                MustGatherServiceNodes are the names of the MustGatherService pods'
-              items:
-                type: string
-              type: array
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
     served: true
     storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        description: MustGatherService is the Schema for the mustgatherservices API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MustGatherServiceSpec defines the desired state of MustGatherService
+            properties:
+              mustGather:
+                description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                  Important: Run "operator-sdk generate k8s" to regenerate code after
+                  modifying this file Add custom validation using kubebuilder tags:
+                  https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+                properties:
+                  command:
+                    description: MustGatherService startup command, default value is
+                      "/bin/must-gather-service -v 1"
+                    items:
+                      type: string
+                    type: array
+                  hostNetwork:
+                    description: MustGatherService deployment hostnetwork, default is
+                      false
+                    type: boolean
+                  image:
+                    description: deprecated, define image in operator.yaml
+                    properties:
+                      pullPolicy:
+                        description: image pull policy, default is IfNotPresent
+                        type: string
+                      repository:
+                        description: image repository, default is empty
+                        type: string
+                      tag:
+                        description: image tag, default is empty
+                        type: string
+                    required:
+                    - repository
+                    - tag
+                    type: object
+                  name:
+                    description: MustGatherService deployment name
+                    type: string
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: MustGatherService deployment node selector, default
+                      is empty
+                    type: object
+                  replicas:
+                    description: MustGatherService pod replicas, default is 1
+                    format: int32
+                    type: integer
+                  resources:
+                    description: resources defines the desired state of Resources
+                    properties:
+                      limits:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                        type: object
+                      requests:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                        type: object
+                    type: object
+                  securityContext:
+                    description: MustGatherService deployment security context, default
+                      is empty
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: 'AllowPrivilegeEscalation controls whether a process
+                          can gain more privileges than its parent process. This bool
+                          directly controls if the no_new_privs flag will be set on
+                          the container process. AllowPrivilegeEscalation is true always
+                          when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                        type: boolean
+                      capabilities:
+                        description: The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the
+                          container runtime.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities type
+                              type: string
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities type
+                              type: string
+                            type: array
+                        type: object
+                      privileged:
+                        description: Run container in privileged mode. Processes in
+                          privileged containers are essentially equivalent to root on
+                          the host. Defaults to false.
+                        type: boolean
+                      procMount:
+                        description: procMount denotes the type of proc mount to use
+                          for the containers. The default is DefaultProcMount which
+                          uses the container runtime defaults for readonly paths and
+                          masked paths. This requires the ProcMountType feature flag
+                          to be enabled.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: Whether this container has a read-only root filesystem.
+                          Default is false.
+                        type: boolean
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set in
+                          PodSecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail to
+                          start the container if it does. If unset or false, no such
+                          validation will be performed. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if unspecified.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext
+                          and PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to the container.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies to
+                              the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies to
+                              the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies to
+                              the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies to
+                              the container.
+                            type: string
+                        type: object
+                      windowsOptions:
+                        description: The Windows specific settings applied to all containers.
+                          If unspecified, the options from the PodSecurityContext will
+                          be used. If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field. This field is alpha-level
+                              and is only honored by servers that enable the WindowsGMSA
+                              feature flag.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the GMSA
+                              credential spec to use. This field is alpha-level and
+                              is only honored by servers that enable the WindowsGMSA
+                              feature flag.
+                            type: string
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in PodSecurityContext.
+                              If set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence.
+                              This field is alpha-level and it is only honored by servers
+                              that enable the WindowsRunAsUserName feature flag.
+                            type: string
+                        type: object
+                    type: object
+                  serviceAccountName:
+                    description: MustGatherService deployment ServiceAccountName, default
+                      is default
+                    type: string
+                  tolerations:
+                    description: MustGatherService deployment tolerations, default is
+                      empty
+                    items:
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using the
+                        matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match. Empty
+                            means match all taint effects. When specified, allowed values
+                            are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to the
+                            value. Valid operators are Exists and Equal. Defaults to
+                            Equal. Exists is equivalent to wildcard for value, so that
+                            a pod can tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of time
+                            the toleration (which must be of effect NoExecute, otherwise
+                            this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do
+                            not evict). Zero and negative values will be treated as
+                            0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                required:
+                - name
+                type: object
+              persistentVolumeClaim:
+                description: persistentVolumeClaim defines the desired persistent volume
+                  claim
+                properties:
+                  name:
+                    description: MustGatherService pvc name
+                    type: string
+                  resources:
+                    description: resources defines the request storage size
+                    properties:
+                      limits:
+                        additionalProperties:
+                          type: string
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          type: string
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                  storageClassName:
+                    description: storageClassName defines the storageclass name, default
+                      is default storageclass in cluster
+                    type: string
+                required:
+                - name
+                type: object
+            type: object
+          status:
+            description: MustGatherServiceStatus defines the observed state of MustGatherService
+            properties:
+              mustGatherServiceNodes:
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                  of cluster Important: Run "operator-sdk generate k8s" to regenerate
+                  code after modifying this file Add custom validation using kubebuilder
+                  tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
+                  MustGatherServiceNodes are the names of the MustGatherService pods'
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object

--- a/deploy/olm-catalog/ibm-healthcheck-operator/ibm-healthcheck-operator.package.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/ibm-healthcheck-operator.package.yaml
@@ -1,9 +1,11 @@
 channels:
   - currentCSV: ibm-healthcheck-operator.v3.8.0
     name: beta
-  - currentCSV: ibm-healthcheck-operator.v3.10.0
+  - currentCSV: ibm-healthcheck-operator.v3.11.0
     name: dev
   - currentCSV: ibm-healthcheck-operator.v3.7.2
     name: stable-v1
+  - currentCSV: ibm-healthcheck-operator.v3.10.0
+    name: v3  
 defaultChannel: stable-v1
 packageName: ibm-healthcheck-operator-app


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to update the `apiextensions.k8s.io/v1beta1` to `apiextensions.k8s.io/v1`.

Also to take care of schematic changes + supported API changes for the relevant CRDs.

More details about API Migration Guide https://kubernetes.io/docs/reference/using-api/deprecation-guide/

Structural Schema has been changed https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#specifying-a-structural-schema


<br class="Apple-interchange-newline">

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/47506



**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
```
