### PR TITLE
Operand version bumpup for ubi image update

### DIFF
--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.11.0/ibm-healthcheck-operator.v3.11.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.11.0/ibm-healthcheck-operator.v3.11.0.clusterserviceversion.yaml
@@ -312,7 +312,7 @@ spec:
                 - name: ICP_MEMCACHED_IMAGE
                   value: "quay.io/opencloudio/icp-memcached:3.9.1"
                 - name: MUST_GATHER_IMAGE
-                  value: "quay.io/opencloudio/must-gather:4.5.6"
+                  value: "quay.io/opencloudio/must-gather:4.5.7"
                 - name: MUST_GATHER_SERVICE_IMAGE
                   value: "quay.io/opencloudio/must-gather-service:1.2.4"
                 image: quay.io/opencloudio/ibm-healthcheck-operator:latest

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.11.0/ibm-healthcheck-operator.v3.11.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.11.0/ibm-healthcheck-operator.v3.11.0.clusterserviceversion.yaml
@@ -308,9 +308,9 @@ spec:
                 - name: OPERATOR_NAME
                   value: ibm-healthcheck-operator
                 - name: SYSTEM_HEALTHCHECK_SERVICE_IMAGE
-                  value: "quay.io/opencloudio/system-healthcheck-service:3.9.2"
+                  value: "quay.io/opencloudio/system-healthcheck-service:3.9.3"
                 - name: ICP_MEMCACHED_IMAGE
-                  value: "quay.io/opencloudio/icp-memcached:3.9.1"
+                  value: "quay.io/opencloudio/icp-memcached:3.9.2"
                 - name: MUST_GATHER_IMAGE
                   value: "quay.io/opencloudio/must-gather:4.5.7"
                 - name: MUST_GATHER_SERVICE_IMAGE

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -57,9 +57,9 @@ spec:
             - name: OPERATOR_NAME
               value: "ibm-healthcheck-operator"
             - name: SYSTEM_HEALTHCHECK_SERVICE_IMAGE
-              value: "quay.io/opencloudio/system-healthcheck-service:3.9.2"
+              value: "quay.io/opencloudio/system-healthcheck-service:3.9.3"
             - name: ICP_MEMCACHED_IMAGE
-              value: "quay.io/opencloudio/icp-memcached:3.9.1"
+              value: "quay.io/opencloudio/icp-memcached:3.9.2"
             - name: MUST_GATHER_IMAGE
               value: "quay.io/opencloudio/must-gather:4.5.7"
             - name: MUST_GATHER_SERVICE_IMAGE

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -61,7 +61,7 @@ spec:
             - name: ICP_MEMCACHED_IMAGE
               value: "quay.io/opencloudio/icp-memcached:3.9.1"
             - name: MUST_GATHER_IMAGE
-              value: "quay.io/opencloudio/must-gather:4.5.6"
+              value: "quay.io/opencloudio/must-gather:4.5.7"
             - name: MUST_GATHER_SERVICE_IMAGE
               value: "quay.io/opencloudio/must-gather-service:1.2.4"
           resources:


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump up operands versions:
system-healthcheck-service: 3.9.3
icp-memcached: 3.9.2
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
```
