### PR TITLE
Bumpup operator version for 3.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Red Hat OpenShift Container Platform 4.3 or newer installed on one of the follow
 - Linux on IBM Z and LinuxONE
 
 ## Operator versions
-
+- 3.12.0
+    - Support for OpenShift 4.4, 4.5 , 4.6 , 4.7 , 4.8.
 - 3.11.0
     - Support for OpenShift 4.4, 4.5 and 4.6.
 - 3.10.0

--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ Red Hat OpenShift Container Platform 4.3 or newer installed on one of the follow
 - Linux on IBM Z and LinuxONE
 
 ## Operator versions
+
 - 3.12.0
-    - Support for OpenShift 4.4, 4.5 , 4.6 , 4.7 , 4.8.
+    - Support for OpenShift 4.4, 4.5 , 4.6 , 4.7 and 4.8.
 - 3.11.0
     - Support for OpenShift 4.4, 4.5 and 4.6.
 - 3.10.0

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.12.0/clusterhealth.ibm.com_clusterservicestatuses_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.12.0/clusterhealth.ibm.com_clusterservicestatuses_crd.yaml
@@ -1,0 +1,61 @@
+###############################################################################
+# Licensed Materials - Property of IBM
+# (C) Copyright IBM Corporation 2019, 2020 All Rights Reserved
+# US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+###############################################################################
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterservicestatuses.clusterhealth.ibm.com
+  labels:
+    app.kubernetes.io/instance: ibm-healthcheck-operator
+    app.kubernetes.io/managed-by: ibm-healthcheck-operator
+    app.kubernetes.io/name: ibm-healthcheck-operator
+spec:
+  group: clusterhealth.ibm.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            status:
+              type: object
+              properties:
+                currentState:
+                  type: string
+                restartCount:
+                  type: integer
+                statusDependencies:
+                  type: array
+                  items: {
+                    type: string
+                  }
+                podFailureStatus:
+                  type: object
+      additionalPrinterColumns:
+      -
+        name: Service Name
+        type: string
+        description: The name of the service
+        jsonPath: .metadata.labels.clusterhealth\.ibm\.com/service-name
+      -
+        name: Service Version
+        type: string
+        description: The version of the service
+        jsonPath: .metadata.labels.clusterhealth\.ibm\.com/service-version
+      -
+        name: Status
+        type: string
+        description: The current status of the service
+        jsonPath: .status.currentState                        
+  scope: Cluster
+  names:
+    kind: ClusterServiceStatus
+    singular: clusterservicestatus
+    plural: clusterservicestatuses
+    shortNames:
+    - css

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.12.0/ibm-healthcheck-operator.v3.12.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.12.0/ibm-healthcheck-operator.v3.12.0.clusterserviceversion.yaml
@@ -1,0 +1,476 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    olm.skipRange: '>=3.5.0 <3.12.0'
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "operator.ibm.com/v1alpha1",
+          "kind": "HealthService",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/instance": "ibm-healthcheck-operator",
+              "app.kubernetes.io/managed-by": "ibm-healthcheck-operator",
+              "app.kubernetes.io/name": "ibm-healthcheck-operator"
+            },
+            "name": "system-healthcheck-service"
+          },
+          "spec": {
+            "healthService": {
+              "configmapName": "system-healthcheck-service-config",
+              "name": "system-healthcheck-service",
+              "replicas": 1,
+              "resources": {
+                "limits": {
+                  "cpu": "500m",
+                  "memory": "512Mi"
+                },
+                "requests": {
+                  "cpu": "50m",
+                  "memory": "64Mi"
+                }
+              },
+              "serviceNameSetting": "Annotations:productName"
+            },
+            "memcached": {
+              "command": [
+                "memcached",
+                "-m 64",
+                "-o",
+                "modern",
+                "-v"
+              ],
+              "name": "icp-memcached",
+              "replicas": 1,
+              "resources": {
+                "limits": {
+                  "cpu": "500m",
+                  "memory": "512Mi"
+                },
+                "requests": {
+                  "cpu": "50m",
+                  "memory": "64Mi"
+                }
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "operator.ibm.com/v1alpha1",
+          "kind": "MustGatherConfig",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/instance": "ibm-healthcheck-operator",
+              "app.kubernetes.io/managed-by": "ibm-healthcheck-operator",
+              "app.kubernetes.io/name": "ibm-healthcheck-operator"
+            },
+            "name": "must-gather-common-service-config"
+          },
+          "spec": {
+            "gatherConfig": "modules=\"overview,failure,cloudpak\"\nnamespaces=\"common-service,ibm-common-services\"\nlabels=\"\""
+          }
+        },
+        {
+          "apiVersion": "operator.ibm.com/v1alpha1",
+          "kind": "MustGatherConfig",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/instance": "ibm-healthcheck-operator",
+              "app.kubernetes.io/managed-by": "ibm-healthcheck-operator",
+              "app.kubernetes.io/name": "ibm-healthcheck-operator"
+            },
+            "name": "must-gather-default-config"
+          },
+          "spec": {
+            "gatherConfig": "modules=\"overview,system,failure,ocp,cloudpak\"\nnamespaces=\"common-service,ibm-common-services\"\nlabels=\"\""
+          }
+        },
+        {
+          "apiVersion": "operator.ibm.com/v1alpha1",
+          "kind": "MustGatherJob",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/instance": "ibm-healthcheck-operator",
+              "app.kubernetes.io/managed-by": "ibm-healthcheck-operator",
+              "app.kubernetes.io/name": "ibm-healthcheck-operator"
+            },
+            "name": "example-mustgatherjob"
+          },
+          "spec": {
+            "mustgatherConfigName": "must-gather-common-service-config",
+            "serviceAccountName": "ibm-mustgather-admin"
+          }
+        },
+        {
+          "apiVersion": "operator.ibm.com/v1alpha1",
+          "kind": "MustGatherService",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/instance": "ibm-healthcheck-operator",
+              "app.kubernetes.io/managed-by": "ibm-healthcheck-operator",
+              "app.kubernetes.io/name": "ibm-healthcheck-operator"
+            },
+            "name": "must-gather-service"
+          },
+          "spec": {
+            "mustGather": {
+              "replicas": 1,
+              "name": "must-gather-service",
+              "resources": {
+                "limits": {
+                  "cpu": "500m",
+                  "memory": "512Mi"
+                },
+                "requests": {
+                  "cpu": "50m",
+                  "memory": "64Mi"
+                }
+              }
+            },
+            "persistentVolumeClaim": {
+              "name": "must-gather-pvc",
+              "resources": {
+                "requests": {
+                  "storage": "5Gi"
+                }
+              },
+              "storageClassName": ""
+            }
+          }
+        }
+      ]
+    capabilities: Basic Install
+    categories: Monitoring
+    certified: "false"
+    containerImage: quay.io/opencloudio/ibm-healthcheck-operator:latest
+    createdAt: "2020-09-16"
+    description: You can use the ibm-healthcheck-operator to install the IBM System Healthcheck service. You can use IBM System Healthcheck service to check the service status of the IBM Cloud Paks and IBM Cloud Platform Common Services.
+    repository: https://github.com/IBM/ibm-healthcheck-operator
+    support: IBM
+  name: ibm-healthcheck-operator.v3.12.0
+  namespace: placeholder
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.s390x: supported
+    operatorframework.io/os.linux: supported
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: 'Documentation For additional details regarding install parameters check: https://ibm.biz/icpfs39install. License By installing this product you accept the license terms https://ibm.biz/icpfs39license'
+      kind: HealthService
+      name: healthservices.operator.ibm.com
+      version: v1alpha1
+      displayName: IBM Health Check Services
+      resources:
+      - kind: deployments
+        name: A Kubernetes Deployment
+        version: v1
+      - kind: services
+        name: A Kubernetes Service
+        version: v1
+      - kind: servicemonitors
+        name: A Kubernetes Servicemonitor
+        version: v1
+      - kind: ingresses
+        name: A Kubernetes Ingress
+        version: v1beta1
+      - kind: pods
+        name: A Kubernetes Pod
+        version: v1
+      - kind: configmaps
+        name: A Kubernetes Configmap
+        version: v1
+      - kind: healthservices
+        name: healthservice operator
+        version: v1alpha1
+      - kind: replicasets
+        name: A Kubernetes Replicaset
+        version: v1
+      specDescriptors:
+      - description: HealthService defines the desired state of HealthService.HealthService
+        displayName: Health Service
+        path: healthService
+      - description: Memcached defines the desired state of HealthService.Memcached
+        displayName: Memcached
+        path: memcached
+      statusDescriptors:
+      - description: HealthCheckNodes are the names of the Healch Service pods
+        displayName: Healch Service Nodes
+        path: healthCheckNodes
+      - description: MemcachedNodes are the names of the memcached pods
+        displayName: Memcached Nodes
+        path: memcachedNodes
+    - description: 'Documentation For additional details regarding install parameters check: https://ibm.biz/icpfs39install. License By installing this product you accept the license terms https://ibm.biz/icpfs39license'
+      kind: ClusterServiceStatus
+      name: clusterservicestatuses.clusterhealth.ibm.com
+      version: v1
+      displayName: IBM Health Services ClusterServiceStatus
+    - description: 'Documentation For additional details regarding install parameters check: https://ibm.biz/icpfs39install. License By installing this product you accept the license terms https://ibm.biz/icpfs39license'
+      kind: MustGatherService
+      name: mustgatherservices.operator.ibm.com
+      version: v1alpha1
+      displayName: IBM Must Gather Services
+    - description: 'Documentation For additional details regarding install parameters check: https://ibm.biz/icpfs39install. License By installing this product you accept the license terms https://ibm.biz/icpfs39license'
+      kind: MustGatherJob
+      name: mustgatherjobs.operator.ibm.com
+      version: v1alpha1
+      displayName: IBM Must Gather Jobs
+    - description: 'Documentation For additional details regarding install parameters check: https://ibm.biz/icpfs39install. License By installing this product you accept the license terms https://ibm.biz/icpfs39license'
+      kind: MustGatherConfig
+      name: mustgatherconfigs.operator.ibm.com
+      version: v1alpha1
+      displayName: IBM Must Gather Configs
+  description: "**Important:** Do not install this operator directly. Only install this operator using the IBM Common Services Operator. For more information about installing this operator and other Common Services operators, see [Installer documentation](http://ibm.biz/cpcs_opinstall).\n\n If you are using this operator as part of an IBM Cloud Pak, see the documentation for that IBM Cloud Pak to learn more about how to install and use the operator service. For more information about IBM Cloud Paks, see [IBM Cloud Paks that use Common Services](http://ibm.biz/cpcs_cloudpaks).\n\nYou can use the ibm-healthcheck-operator to install the IBM System Healthcheck service. You can use IBM System Healthcheck service to check the service status of the IBM Cloud Paks and IBM Cloud Platform Common Services. \n\nFor more information about the available IBM Cloud Platform Common Services, see the [IBM Knowledge Center](http://ibm.biz/cpcsdocs). \n## Supported platforms \n\n Red Hat OpenShift Container Platform 4.3 or newer installed on one of the following platforms: \n\n- Linux x86_64 \n- Linux on Power (ppc64le) \n- Linux on IBM Z and LinuxONE \n## Prerequisites\n\n Before you install this operator, you need to first install the operator dependencies and prerequisites: \n- For the list of operator dependencies, see the IBM Knowledge Center [Common Services dependencies documentation](http://ibm.biz/cpcs_opdependencies). \n- For the list of prerequisites for installing the operator, see the IBM Knowledge Center [Preparing to install services documentation](http://ibm.biz/cpcs_opinstprereq). \n## Documentation \n\n To install the operator with the IBM Common Services Operator follow the the installation and configuration instructions within the IBM Knowledge Center. \n- If you are using the operator as part of an IBM Cloud Pak, see the documentation for that IBM Cloud Pak, for a list of IBM Cloud Paks, see [IBM Cloud Paks that use Common Services](http://ibm.biz/cpcs_cloudpaks). \n- If you are using the operator with an IBM Containerized Software, see the IBM Cloud Platform Common Services Knowledge Center [Installer documentation](http://ibm.biz/cpcs_opinstall)."
+  displayName: IBM Health Check Operator
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAK8AAACvCAMAAAC8TH5HAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAB1UExURQAAAJGS77CC4pCS75yM64uV8pSQ7puA85OV87OB4auF5Hyd+H2c936b9n6b94Ca9n+b9n+b9n+b9qOJ56SI55yM6qSI536b96aH5q2D45mN64OZ9ZWQ7oyU8XWg+6uG5oqg/p6L6m+k/ZuY+3mr/6qQ9LqM80D8C0oAAAAbdFJOUwA67R4KKxMBBP6ak6vZgVtJxG5ot+hQ7YDVkwC2C58AAAuSSURBVHja7ZyJerK8EoCDCSTKjoiIS13of/+XeGYm4NLKrvj1OYxt7aa8TiazJZGxSSaZZJJJJvmcSCn/Eq7Cz79DLJk0rb+kXdM9nz0m/4p2mZufz3lAZvEn1HsGye2J9128h7/Gezj8Nd7D3+I9/xu8SjWHrS76bfN8A+NsYxjowCvbPN+QSGB6kWi6QHteyQLPfx+wYsH2eHSthgu05lXMy/PceRcwxtnjdnts4mjLq5hBceVdcVsya71FMeov0JIXMuQwR+DoXX5EMgf0uz2GrDYbb8mrmE+4Z/NdvDCApN+jX3uFdrySqfW70wzFbFLwWtVNkXa8ONlIvfx9Dk0xSyvYq0NpxasYJ9o8emcUVCw6EjGvuUpLXgfVm9cP1fAZp1yyCKeGBf8pB96g9jUZ57c6s1vIIAUfjXqY9eFg1yiuKJnOECzeW+TJm0+rxRGGWfcP7/dld8bZwqcp/dJqIs9hrJIJ/JD2abV5j1StfJn1/pofo/Kx0ae1KfAO7/Vld7anfVpf28M5kKPDc9kYLRW4RDhIwYV/PozVUAF39Qre3BmrvsM04nisjHHyJlUjZEOefuBj8UIA81zHfGJ84BYeHAP9LKseP1r5LNnvOlHeXJgqRZbUPzT97PHvBVb48VCX09W54du2u3ZJwjD0It/gqmCue/yoolm4b7tQjmohh7cGAWzHC8x/qOFOZmBG4bbERDkQrVYyiGP7iPwPLGrgsAofYbePonEJ2CHxAuvjxEjLvfUj7J1BaP0irY3i888SA63l3alWgwKjbXueZztOSBoucOE33huIZdsWHChXRds72O069PyHhSEBDiOynbAEBiGreCGJKoa5zT8GVBzt4QNgXc+wbq4YvW+hSMkDYNa4EYihWqlYtmouSsYTo4XvgWezHKDcI+7xuPbMMp7JH0GEfhZGRMDIG5FRtLG1IGCNvTp/d9nFZhMx/DXYH/cgSBv6SscM+Tyf0P450Lw+iCmbOGAMonOeO/XlMyTjgAsfmWAN9Y53RFy0hDAovXBDSBFBVAIHDdUJ2lre3J6AVG9Hcln5NQyKCUcrd390g5/BtjpNR2KNGwTVpRDSmk6et6jwCv0ScVhpxopxl3DBIjzVjrYk5gVuEPAaw7UP+aFV+0ex5Aq8y/hTYhiE/UXjhibrlBUisUm8hmHwqujuH3IqQLA/0dT+Af8Q34hT8du3QXlR4nrdkxhJ0554nwAXhpvj+hLUo2u/zWoJM1aXy70ZP8e97APWJ+WGbN1AXNP8tedAasM96PLu4Ik2jhpHZLkqgdGM5TNjuKzNnhkiUmneH8CSCe9wpXV429HDlCu7GcV9JwemWoEbWr3rGZx2iMs5F4+T3S1p89DoYGvkUeLCKC67m+uBsVwVuGpI+QVohGtZ6rHrU+Cu/UaP/ps4KY3iWhlipwNwd4Arh1WLCIy4lpA/2yiF4XZ9ehgMuaRgt7r6FMWiC9DuL64YWtyCrQKuEOLe1iJsG+eO2W8eo+POdrvVtdULrgG0Dbg76xW1uCDcm5GCguzDAeNlz0qPqgfzGunJeAl4aOug6KYQ7l2WhI7DZEMqZ7L5a1uBZWTQF3/QVHvmUosOBX0ZVkbfkgNtDYCbDcDVsIKbQYCJBCY/gak7FHQh+bqiX7LwsnuYfr1gqUTCUsPWgsWdF1H2I1/ZoYBMSLs3o3/blyke+FRiEPE9c1Huq9dpV60GWQNmvybSIrCnee0SGIlDJzJfVzwrttTq7bfkUNCSzV71a19pScNOGHrmi9pWV/Uue6lXYpEcBFfgslSOPG0MBTASc/YK3455PEqvyYY5r0G4AeH6gWHqSCyVxQ2s9ksJw9B/ATBYVUy8fdRL6ZhhlPo1HpIyHelM38OmCuA6oWvzwTah69DTbiW6qxdMCdPdAIGLbrC8lyIimxHRgrhQcA+cdoqluxXc0u7qhcTGNBAYeKkB9CTASfJjVuTo7mvoRsO676Ci+LRanVbd91YgLggp2GI1/kpRq7MAXnuDjBhC8Qpkl3UepwIXgblseDQq2XBcUK8bru0hGgbni7ynzrMNs1xOuJDmNQMAsfAI2B0CjOaAvKuuK2aES8C8XU8Sn98H9SKw12/SwfwVzNyArOLOL1lxEpO37/lKFujlpW3UfTSZwpxaQCkXb+JVd3OAAg1xrQ4vFGzC0MDrbuvLSGtRiSVYuonjeNU5MxMWAVudZzct1azdLmUXzGZLV7BCySxG6Zrq4MsFXqv79A7WiLu1OwwLFgElr7VA3LQjLtZnCCx7+KNo7a4BuG3lhRmKWXQ0LME40Gbxsqt6BQH3arExZ+viCl67Ib1rGHFLQPIQL7JFnHTjRfUCb68whR1mXM3dttpjcWvIAS6uNCRxlmVxxypeCVJw3wjl0/LzmrfaVG4kBgFT6ge57wJ4M7OTfmlNS4j+McpB4G2rTfBGkhAwp2UcWfB2cw/FFogBKQvxrhtTLMnMZYJiFG4eeLM0zVLRg3dIzmJvAbfRgiXjS81rXfeBLIE3TTuVQneZeH8Fb4HXFQ0rcGKJcsNFXsRdduYdViSQBQNy0LCilaSIu+R3TeqP8KKLQAXXzjgw3hR5l3erFvoldOOVr9Cv5eK6v1tzXch0UZfLNGEPvGQi3fU7tMi1m45PgCtb4Nin974Lftmd9yUtJZ94q/NgUG9KvA9rWOjgwKATMTqv3mpcbcDgQxaLRbpYyp+89/5tLMF98GTAVZsP4LfpAuXRYnALBwof+0AxejR0EVVpO4ARbvpz96D1GV7FvNoJB4lNDLiQOKofIQSTicQcnzeq5ZUsxTpi8ctQJeVrJmNj8wbEWxHhYNxjXff8UiT1vww1Oq9R59Dgz1gGb5Kff5a62jA/4tD222Ml75J4zd+8uglmfcQB76s2nktsM2w2z8p2yamWG90eTNrd9ly/ALnAtlP8LO5a1FdSo9sv7h3cVvGqGHkXT9Sr+3ZcjO4faNNYUMErkHf2tIeuqBNhjc0bHXEDoVHBa20qeRm1liw1Mq9H29z68Ard+hs7f0BzWD/3S8g7q+TV3RohR8VVLqq34pgR2G8NL9O8alx3Rrvy7Cr3q2LkXTyPClrBY55JgPqCthFGVbxsgbxxRd2jxKCGTS/zpelW0beD8pB4NxVhVw7t2HSvj0m9lfUx5A/zzWw2q0yPHzYHjWEOuDXvWLnhAtL1Gah3XrWsImkL/WjAkoX7au+r00bQ7my+qFr4ekETpFvyUGsOKOAgZrNNZaE2InCx9XF/qVmFQwNGBVevs42n31K9+5oqFxw0GURc22UayXjBenHrY1Z7UJ/FpOCkRsFjWe+SNsLuef2xCm0QMfvwe60pxnGf5v7iNTR/xWZWb8GjWcOFgBtK3FLBM+uTCpatd5aigue1Pngs4yVcp8VphmT+YYuQGIhxm/Fu37w+j0mPBk4+BIy4ett8q52lGJTneJsbHwHGwx/FQYp2Q6wtogCWH8DNLtdt0S1Pi6RICx8JG1nFCluOV9yWLgrrjAI4HfVQNtYu5emw9ri0EyZGWpCNORYxvVuAGZeHgLIuEVZB5UnAqGLryfsLvDx31Gfa6czSSW+D7XRFVZgEyizlRfEm3yJFSaiM+HQ5Ee5ll3SNVgCczkvi+SJ5c+PMMtIV0BLu6RL32P8Lry8pcVHJcZoYlniDcCNJ49Xp+/uk5QK20PP0kLWYP8qsg2zuvl/VyAlQS1bQ7SnjfQ814O7WeF4jX/P/5l//fT2V77svePeNd/gFNam/FN/eZPd9io0B/ojOwMWVsA8/wO1RZvc/nOgTbqfi7okAfDbUe+KDjcVsPq9X81eJPK/g/So476kfWUG1S6vjmcIqYpGkGwT7r4t8FfffdIP7ajmdNlnC2Qto2fWNtixjudRr4a+VLF0uTa4vJF8XKuXbg/Hr33TjffKn3gp/kkkmmWSSSSaZZJJJJplkkkkmmWSS/yf5H6HANgUotAMHAAAAAElFTkSuQmCC
+    mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - clusterhealth.ibm.com
+          resources:
+          - clusterservicestatuses
+          verbs:
+          - '*'
+        - apiGroups:
+          - ''
+          resources:
+          - pods
+          - nodes
+          verbs:
+          - get
+          - list
+        serviceAccountName: ibm-healthcheck-operator-cluster
+      - rules:
+        - apiGroups:
+          - '*'
+          resources:
+          - '*'
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - ''
+          resources:
+          - pods/exec
+          verbs:
+          - create
+        serviceAccountName: ibm-mustgather-admin
+      deployments:
+      - name: ibm-healthcheck-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: ibm-healthcheck-operator
+          strategy: {}
+          template:
+            metadata:
+              annotations:
+                productID: 068a62892a1e4db39641342e592daa25
+                productMetric: FREE
+                productName: IBM Cloud Platform Common Services
+              labels:
+                app.kubernetes.io/instance: ibm-healthcheck-operator
+                app.kubernetes.io/managed-by: ibm-healthcheck-operator
+                app.kubernetes.io/name: ibm-healthcheck-operator
+                name: ibm-healthcheck-operator
+            spec:
+              affinity:
+                nodeAffinity:
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    nodeSelectorTerms:
+                    - matchExpressions:
+                      - key: beta.kubernetes.io/arch
+                        operator: In
+                        values:
+                        - amd64
+                        - ppc64le
+                        - s390x
+              containers:
+              - command:
+                - ibm-healthcheck-operator
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: ibm-healthcheck-operator
+                - name: SYSTEM_HEALTHCHECK_SERVICE_IMAGE
+                  value: "quay.io/opencloudio/system-healthcheck-service:3.9.3"
+                - name: ICP_MEMCACHED_IMAGE
+                  value: "quay.io/opencloudio/icp-memcached:3.9.2"
+                - name: MUST_GATHER_IMAGE
+                  value: "quay.io/opencloudio/must-gather:4.5.7"
+                - name: MUST_GATHER_SERVICE_IMAGE
+                  value: "quay.io/opencloudio/must-gather-service:1.2.4"
+                image: quay.io/opencloudio/ibm-healthcheck-operator:latest
+                imagePullPolicy: Always
+                name: ibm-healthcheck-operator
+                resources:
+                  limits:
+                    cpu: 160m
+                    memory: 512Mi
+                  requests:
+                    cpu: 10m
+                    memory: 32Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+                  privileged: false
+                  readOnlyRootFilesystem: true
+                  runAsNonRoot: true
+              serviceAccountName: ibm-healthcheck-operator
+      permissions:
+      - rules:
+        - apiGroups:
+          - extensions
+          resources:
+          - ingresses
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - services/finalizers
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - apps
+          resourceNames:
+          - ibm-healthcheck-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - replicasets
+          - deployments
+          verbs:
+          - get
+        - apiGroups:
+          - operator.ibm.com
+          resources:
+          - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - clusterhealth.ibm.com
+          resources:
+          - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        serviceAccountName: ibm-healthcheck-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  maturity: alpha
+  minKubeVersion: 1.19.0
+  provider:
+    name: IBM
+  replaces: ibm-healthcheck-operator.v3.11.0
+  version: 3.12.0
+  links:
+  - name: IBM Health Check Operator
+    url: https://github.com/IBM/ibm-healthcheck-operator
+  maintainers:
+  - email: support@ibm.com
+    name: IBM Support
+  keywords:
+  - IBM
+  - Cloud
+  - Monitoring
+  - Healthcheck

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.12.0/operator.ibm.com_healthservices_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.12.0/operator.ibm.com_healthservices_crd.yaml
@@ -1,0 +1,519 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: healthservices.operator.ibm.com
+  labels:
+    app.kubernetes.io/instance: ibm-healthcheck-operator
+    app.kubernetes.io/managed-by: ibm-healthcheck-operator
+    app.kubernetes.io/name: ibm-healthcheck-operator
+spec:
+  group: operator.ibm.com
+  names:
+    kind: HealthService
+    listKind: HealthServiceList
+    plural: healthservices
+    singular: healthservice
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        description: HealthService is the Schema for the healthservices API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HealthServiceSpec defines the desired state of HealthService
+            properties:
+              healthService:
+                description: HealthService defines the desired state of HealthService.HealthService
+                properties:
+                  cloudpakNameSetting:
+                    description: set labels/annotation name to get pod's cloudpakname
+                    type: string
+                  configmapName:
+                    description: configmap which contains health srevice configuration
+                      files, deprecated
+                    type: string
+                  dependsSetting:
+                    description: set labels/annotation name to get pod's dependencies
+                    type: string
+                  hostNetwork:
+                    description: health srevice deployment hostnetwork, default is false
+                    type: boolean
+                  image:
+                    description: deprecated, define image in operator.yaml
+                    properties:
+                      pullPolicy:
+                        description: image pull policy, default is IfNotPresent
+                        type: string
+                      repository:
+                        description: image repository, default is empty
+                        type: string
+                      tag:
+                        description: image tag, default is empty
+                        type: string
+                    required:
+                    - repository
+                    - tag
+                    type: object
+                  name:
+                    description: health service deployment name
+                    type: string
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: health srevice deployment node selector, default is
+                      empty
+                    type: object
+                  replicas:
+                    description: health service pod replicas, default is 1
+                    format: int32
+                    type: integer
+                  resources:
+                    description: resources defines the desired state of Resources
+                    properties:
+                      limits:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                        type: object
+                      requests:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                        type: object
+                    type: object
+                  securityContext:
+                    description: memcached deployment security context, default is empty
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: 'AllowPrivilegeEscalation controls whether a process
+                          can gain more privileges than its parent process. This bool
+                          directly controls if the no_new_privs flag will be set on
+                          the container process. AllowPrivilegeEscalation is true always
+                          when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                        type: boolean
+                      capabilities:
+                        description: The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the
+                          container runtime.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities type
+                              type: string
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities type
+                              type: string
+                            type: array
+                        type: object
+                      privileged:
+                        description: Run container in privileged mode. Processes in
+                          privileged containers are essentially equivalent to root on
+                          the host. Defaults to false.
+                        type: boolean
+                      procMount:
+                        description: procMount denotes the type of proc mount to use
+                          for the containers. The default is DefaultProcMount which
+                          uses the container runtime defaults for readonly paths and
+                          masked paths. This requires the ProcMountType feature flag
+                          to be enabled.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: Whether this container has a read-only root filesystem.
+                          Default is false.
+                        type: boolean
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set in
+                          PodSecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail to
+                          start the container if it does. If unset or false, no such
+                          validation will be performed. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if unspecified.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext
+                          and PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to the container.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies to
+                              the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies to
+                              the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies to
+                              the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies to
+                              the container.
+                            type: string
+                        type: object
+                      windowsOptions:
+                        description: The Windows specific settings applied to all containers.
+                          If unspecified, the options from the PodSecurityContext will
+                          be used. If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field. This field is alpha-level
+                              and is only honored by servers that enable the WindowsGMSA
+                              feature flag.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the GMSA
+                              credential spec to use. This field is alpha-level and
+                              is only honored by servers that enable the WindowsGMSA
+                              feature flag.
+                            type: string
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in PodSecurityContext.
+                              If set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence.
+                              This field is alpha-level and it is only honored by servers
+                              that enable the WindowsRunAsUserName feature flag.
+                            type: string
+                        type: object
+                    type: object
+                  serviceAccountName:
+                    description: health service deployment ServiceAccountName, default
+                      is default
+                    type: string
+                  serviceNameSetting:
+                    description: set labels/annotation name to get pod's servicename
+                    type: string
+                  tolerations:
+                    description: health srevice deployment tolerations, default is empty
+                    items:
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using the
+                        matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match. Empty
+                            means match all taint effects. When specified, allowed values
+                            are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to the
+                            value. Valid operators are Exists and Equal. Defaults to
+                            Equal. Exists is equivalent to wildcard for value, so that
+                            a pod can tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of time
+                            the toleration (which must be of effect NoExecute, otherwise
+                            this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do
+                            not evict). Zero and negative values will be treated as
+                            0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                required:
+                - configmapName
+                - name
+                type: object
+              memcached:
+                description: Memcached defines the desired state of HealthService.Memcached
+                properties:
+                  command:
+                    description: memcached startup command, default value is "memcached
+                      -m 64 -o modern -v"
+                    items:
+                      type: string
+                    type: array
+                  image:
+                    description: deprecated, define image in operator.yaml
+                    properties:
+                      pullPolicy:
+                        description: image pull policy, default is IfNotPresent
+                        type: string
+                      repository:
+                        description: image repository, default is empty
+                        type: string
+                      tag:
+                        description: image tag, default is empty
+                        type: string
+                    required:
+                    - repository
+                    - tag
+                    type: object
+                  name:
+                    description: memcached deployment name
+                    type: string
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: memcached deployment node selector, default is empty
+                    type: object
+                  replicas:
+                    description: memcached pod replicas, default is 1
+                    format: int32
+                    type: integer
+                  resources:
+                    description: resources defines the desired state of Resources
+                    properties:
+                      limits:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                        type: object
+                      requests:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                        type: object
+                    type: object
+                  securityContext:
+                    description: memcached deployment security context, default is empty
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: 'AllowPrivilegeEscalation controls whether a process
+                          can gain more privileges than its parent process. This bool
+                          directly controls if the no_new_privs flag will be set on
+                          the container process. AllowPrivilegeEscalation is true always
+                          when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                        type: boolean
+                      capabilities:
+                        description: The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the
+                          container runtime.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities type
+                              type: string
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities type
+                              type: string
+                            type: array
+                        type: object
+                      privileged:
+                        description: Run container in privileged mode. Processes in
+                          privileged containers are essentially equivalent to root on
+                          the host. Defaults to false.
+                        type: boolean
+                      procMount:
+                        description: procMount denotes the type of proc mount to use
+                          for the containers. The default is DefaultProcMount which
+                          uses the container runtime defaults for readonly paths and
+                          masked paths. This requires the ProcMountType feature flag
+                          to be enabled.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: Whether this container has a read-only root filesystem.
+                          Default is false.
+                        type: boolean
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set in
+                          PodSecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail to
+                          start the container if it does. If unset or false, no such
+                          validation will be performed. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if unspecified.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext
+                          and PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to the container.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies to
+                              the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies to
+                              the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies to
+                              the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies to
+                              the container.
+                            type: string
+                        type: object
+                      windowsOptions:
+                        description: The Windows specific settings applied to all containers.
+                          If unspecified, the options from the PodSecurityContext will
+                          be used. If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field. This field is alpha-level
+                              and is only honored by servers that enable the WindowsGMSA
+                              feature flag.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the GMSA
+                              credential spec to use. This field is alpha-level and
+                              is only honored by servers that enable the WindowsGMSA
+                              feature flag.
+                            type: string
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in PodSecurityContext.
+                              If set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence.
+                              This field is alpha-level and it is only honored by servers
+                              that enable the WindowsRunAsUserName feature flag.
+                            type: string
+                        type: object
+                    type: object
+                  serviceAccountName:
+                    description: memcached deployment ServiceAccountName, default is
+                      default
+                    type: string
+                  tolerations:
+                    description: memcached deployment tolerations, default is empty
+                    items:
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using the
+                        matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match. Empty
+                            means match all taint effects. When specified, allowed values
+                            are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to the
+                            value. Valid operators are Exists and Equal. Defaults to
+                            Equal. Exists is equivalent to wildcard for value, so that
+                            a pod can tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of time
+                            the toleration (which must be of effect NoExecute, otherwise
+                            this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do
+                            not evict). Zero and negative values will be treated as
+                            0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                required:
+                - name
+                type: object
+            type: object
+          status:
+            description: HealthServiceStatus defines the observed state of HealthService
+            properties:
+              healthCheckNodes:
+                description: HealthCheckNodes are the names of the Healch Service pods
+                items:
+                  type: string
+                type: array
+              memcachedNodes:
+                description: MemcachedNodes are the names of the memcached pods
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object     

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.12.0/operator.ibm.com_mustgatherconfigs_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.12.0/operator.ibm.com_mustgatherconfigs_crd.yaml
@@ -1,0 +1,52 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: mustgatherconfigs.operator.ibm.com
+  labels:
+    app.kubernetes.io/instance: ibm-healthcheck-operator
+    app.kubernetes.io/managed-by: ibm-healthcheck-operator
+    app.kubernetes.io/name: ibm-healthcheck-operator
+spec:
+  group: operator.ibm.com
+  names:
+    kind: MustGatherConfig
+    listKind: MustGatherConfigList
+    plural: mustgatherconfigs
+    singular: mustgatherconfig
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:      
+      openAPIV3Schema:
+        description: MustGatherConfig is the Schema for the mustgatherconfigs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MustGatherConfigSpec defines the desired state of MustGatherConfig
+            properties:
+              gatherConfig:
+                description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                  Important: Run "operator-sdk generate k8s" to regenerate code after
+                  modifying this file Add custom validation using kubebuilder tags:
+                  https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+                type: string
+            type: object
+          status:
+            description: MustGatherConfigStatus defines the observed state of MustGatherConfig
+            type: object
+        type: object

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.12.0/operator.ibm.com_mustgatherjobs_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.12.0/operator.ibm.com_mustgatherjobs_crd.yaml
@@ -1,0 +1,75 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: mustgatherjobs.operator.ibm.com
+  labels:
+    app.kubernetes.io/instance: ibm-healthcheck-operator
+    app.kubernetes.io/managed-by: ibm-healthcheck-operator
+    app.kubernetes.io/name: ibm-healthcheck-operator
+spec:
+  group: operator.ibm.com
+  names:
+    kind: MustGatherJob
+    listKind: MustGatherJobList
+    plural: mustgatherjobs
+    singular: mustgatherjob
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        description: MustGatherJob is the Schema for the mustgatherjobs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MustGatherJobSpec defines the desired state of MustGatherJob
+            properties:
+              image:
+                description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                  Important: Run "operator-sdk generate k8s" to regenerate code after
+                  modifying this file Add custom validation using kubebuilder tags:
+                  https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
+                  must gather image'
+                properties:
+                  pullPolicy:
+                    description: image pull policy, default is IfNotPresent
+                    type: string
+                  repository:
+                    description: image repository, default is empty
+                    type: string
+                  tag:
+                    description: image tag, default is empty
+                    type: string
+                required:
+                - repository
+                - tag
+                type: object
+              mustgatherCommand:
+                description: must gather command, default is gather
+                type: string
+              mustgatherConfigName:
+                description: must gather config name, default is default
+                type: string
+              serviceAccountName:
+                description: must gather job ServiceAccountName, default is default
+                type: string
+            type: object
+          status:
+            description: MustGatherJobStatus defines the observed state of MustGatherJob
+            type: object
+        type: object

--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.12.0/operator.ibm.com_mustgatherservices_crd.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.12.0/operator.ibm.com_mustgatherservices_crd.yaml
@@ -1,0 +1,323 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: mustgatherservices.operator.ibm.com
+  labels:
+    app.kubernetes.io/instance: ibm-healthcheck-operator
+    app.kubernetes.io/managed-by: ibm-healthcheck-operator
+    app.kubernetes.io/name: ibm-healthcheck-operator
+spec:
+  group: operator.ibm.com
+  names:
+    kind: MustGatherService
+    listKind: MustGatherServiceList
+    plural: mustgatherservices
+    singular: mustgatherservice
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        description: MustGatherService is the Schema for the mustgatherservices API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MustGatherServiceSpec defines the desired state of MustGatherService
+            properties:
+              mustGather:
+                description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                  Important: Run "operator-sdk generate k8s" to regenerate code after
+                  modifying this file Add custom validation using kubebuilder tags:
+                  https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+                properties:
+                  command:
+                    description: MustGatherService startup command, default value is
+                      "/bin/must-gather-service -v 1"
+                    items:
+                      type: string
+                    type: array
+                  hostNetwork:
+                    description: MustGatherService deployment hostnetwork, default is
+                      false
+                    type: boolean
+                  image:
+                    description: deprecated, define image in operator.yaml
+                    properties:
+                      pullPolicy:
+                        description: image pull policy, default is IfNotPresent
+                        type: string
+                      repository:
+                        description: image repository, default is empty
+                        type: string
+                      tag:
+                        description: image tag, default is empty
+                        type: string
+                    required:
+                    - repository
+                    - tag
+                    type: object
+                  name:
+                    description: MustGatherService deployment name
+                    type: string
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: MustGatherService deployment node selector, default
+                      is empty
+                    type: object
+                  replicas:
+                    description: MustGatherService pod replicas, default is 1
+                    format: int32
+                    type: integer
+                  resources:
+                    description: resources defines the desired state of Resources
+                    properties:
+                      limits:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                        type: object
+                      requests:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                        type: object
+                    type: object
+                  securityContext:
+                    description: MustGatherService deployment security context, default
+                      is empty
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: 'AllowPrivilegeEscalation controls whether a process
+                          can gain more privileges than its parent process. This bool
+                          directly controls if the no_new_privs flag will be set on
+                          the container process. AllowPrivilegeEscalation is true always
+                          when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                        type: boolean
+                      capabilities:
+                        description: The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the
+                          container runtime.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities type
+                              type: string
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities type
+                              type: string
+                            type: array
+                        type: object
+                      privileged:
+                        description: Run container in privileged mode. Processes in
+                          privileged containers are essentially equivalent to root on
+                          the host. Defaults to false.
+                        type: boolean
+                      procMount:
+                        description: procMount denotes the type of proc mount to use
+                          for the containers. The default is DefaultProcMount which
+                          uses the container runtime defaults for readonly paths and
+                          masked paths. This requires the ProcMountType feature flag
+                          to be enabled.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: Whether this container has a read-only root filesystem.
+                          Default is false.
+                        type: boolean
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set in
+                          PodSecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail to
+                          start the container if it does. If unset or false, no such
+                          validation will be performed. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if unspecified.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext
+                          and PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to the container.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies to
+                              the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies to
+                              the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies to
+                              the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies to
+                              the container.
+                            type: string
+                        type: object
+                      windowsOptions:
+                        description: The Windows specific settings applied to all containers.
+                          If unspecified, the options from the PodSecurityContext will
+                          be used. If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field. This field is alpha-level
+                              and is only honored by servers that enable the WindowsGMSA
+                              feature flag.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the GMSA
+                              credential spec to use. This field is alpha-level and
+                              is only honored by servers that enable the WindowsGMSA
+                              feature flag.
+                            type: string
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in PodSecurityContext.
+                              If set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence.
+                              This field is alpha-level and it is only honored by servers
+                              that enable the WindowsRunAsUserName feature flag.
+                            type: string
+                        type: object
+                    type: object
+                  serviceAccountName:
+                    description: MustGatherService deployment ServiceAccountName, default
+                      is default
+                    type: string
+                  tolerations:
+                    description: MustGatherService deployment tolerations, default is
+                      empty
+                    items:
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using the
+                        matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match. Empty
+                            means match all taint effects. When specified, allowed values
+                            are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to the
+                            value. Valid operators are Exists and Equal. Defaults to
+                            Equal. Exists is equivalent to wildcard for value, so that
+                            a pod can tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of time
+                            the toleration (which must be of effect NoExecute, otherwise
+                            this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do
+                            not evict). Zero and negative values will be treated as
+                            0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                required:
+                - name
+                type: object
+              persistentVolumeClaim:
+                description: persistentVolumeClaim defines the desired persistent volume
+                  claim
+                properties:
+                  name:
+                    description: MustGatherService pvc name
+                    type: string
+                  resources:
+                    description: resources defines the request storage size
+                    properties:
+                      limits:
+                        additionalProperties:
+                          type: string
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          type: string
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                  storageClassName:
+                    description: storageClassName defines the storageclass name, default
+                      is default storageclass in cluster
+                    type: string
+                required:
+                - name
+                type: object
+            type: object
+          status:
+            description: MustGatherServiceStatus defines the observed state of MustGatherService
+            properties:
+              mustGatherServiceNodes:
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                  of cluster Important: Run "operator-sdk generate k8s" to regenerate
+                  code after modifying this file Add custom validation using kubebuilder
+                  tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
+                  MustGatherServiceNodes are the names of the MustGatherService pods'
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object

--- a/deploy/olm-catalog/ibm-healthcheck-operator/ibm-healthcheck-operator.package.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/ibm-healthcheck-operator.package.yaml
@@ -1,11 +1,11 @@
 channels:
   - currentCSV: ibm-healthcheck-operator.v3.8.0
     name: beta
-  - currentCSV: ibm-healthcheck-operator.v3.11.0
+  - currentCSV: ibm-healthcheck-operator.v3.12.0
     name: dev
   - currentCSV: ibm-healthcheck-operator.v3.7.2
     name: stable-v1
-  - currentCSV: ibm-healthcheck-operator.v3.10.0
+  - currentCSV: ibm-healthcheck-operator.v3.11.0
     name: v3  
 defaultChannel: stable-v1
 packageName: ibm-healthcheck-operator-app

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -41,7 +41,7 @@ spec:
       containers:
         - name: ibm-healthcheck-operator
           # Replace this with the built image name
-          image: quay.io/opencloudio/ibm-healthcheck-operator:3.11.0
+          image: quay.io/opencloudio/ibm-healthcheck-operator:3.12.0
           command:
           - ibm-healthcheck-operator
           imagePullPolicy: Always

--- a/version/version.go
+++ b/version/version.go
@@ -17,5 +17,5 @@
 package version
 
 var (
-	Version = "3.11.0"
+	Version = "3.12.0"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumping up operator version to 3.12.0 to support 3.10.0 drop changes

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # NA

