### PR TITLE
Modifying ubi image tag to remediate Twistlock scan issue: 48424

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4-200.1622548483
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4-205.1626828526
 ARG VCS_REF
 ARG VCS_URL
 


### PR DESCRIPTION
Changes for UBI image tag to remediate Twistlock scan issue 48424.