### PR TITLE
Enable UBI Automation for heathcheck operator

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM hyc-cloud-private-edge-docker-local.artifactory.swg-devops.com/build-images/ubi8-minimal:latest
+FROM hyc-cloud-private-edge-docker-local.artifactory.swg-devops.com/build-images/ubi8-minimal
 ARG VCS_REF
 ARG VCS_URL
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM hyc-cloud-private-edge-docker-local.artifactory.swg-devops.com/build-images/ubi8-minimal
+FROM hyc-cloud-private-edge-docker-local.artifactory.swg-devops.com/build-images/ubi8-minimal:latest
 ARG VCS_REF
 ARG VCS_URL
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4-205.1626828526
+FROM hyc-cloud-private-edge-docker-local.artifactory.swg-devops.com/build-images/ubi8-minimal:latest
 ARG VCS_REF
 ARG VCS_URL
 

--- a/common/config/.hadolint.yml
+++ b/common/config/.hadolint.yml
@@ -1,5 +1,6 @@
 ignored:
   - FAKE_DL3003
+  - DL3006
   
 trustedRegistries:
   - gcr.io

--- a/common/config/.hadolint.yml
+++ b/common/config/.hadolint.yml
@@ -6,3 +6,4 @@ trustedRegistries:
   - docker.io
   - quay.io
   - registry.access.redhat.com
+  - hyc-cloud-private-edge-docker-local.artifactory.swg-devops.com

--- a/common/config/.hadolint.yml
+++ b/common/config/.hadolint.yml
@@ -1,6 +1,6 @@
 ignored:
   - FAKE_DL3003
-  - DL3006
+  - DL3007
   
 trustedRegistries:
   - gcr.io

--- a/common/scripts/config_docker.sh
+++ b/common/scripts/config_docker.sh
@@ -17,6 +17,7 @@
 
 KUBECTL=$(command -v kubectl)
 DOCKER_REGISTRY="hyc-cloud-private-integration-docker-local.artifactory.swg-devops.com"
+DOCKER_EDGE_REGISTRY="hyc-cloud-private-edge-docker-local.artifactory.swg-devops.com"
 DOCKER_USERNAME=$(${KUBECTL} -n default get secret artifactory-cred -o jsonpath='{.data.username}' | base64 --decode)
 DOCKER_PASSWORD=$(${KUBECTL} -n default get secret artifactory-cred -o jsonpath='{.data.password}' | base64 --decode)
 
@@ -25,3 +26,6 @@ CONTAINER_CLI=${CONTAINER_CLI:-docker}
 
 # login the docker registry
 ${CONTAINER_CLI} login "${DOCKER_REGISTRY}" -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}"
+
+# login the docker edge registry
+${CONTAINER_CLI} login "${DOCKER_EDGE_REGISTRY}" -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}"


### PR DESCRIPTION
**What this PR does / why we need it**:
This change is to enable the CICD automation for UBI base images.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/48535