### PR TITLE
Changes to support must-gather to run external script

### DIFF
--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.13.0/ibm-healthcheck-operator.v3.13.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.13.0/ibm-healthcheck-operator.v3.13.0.clusterserviceversion.yaml
@@ -273,6 +273,21 @@ spec:
           verbs:
           - create
         serviceAccountName: ibm-mustgather-admin
+      - rules:
+        - apiGroups:
+          - '*'
+          resources:
+          - '*'
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - ''
+          resources:
+          - pods/exec
+          verbs:
+          - create
+        serviceAccountName: ibm-mustgather-custom-sa        
       deployments:
       - name: ibm-healthcheck-operator
         spec:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -176,3 +176,28 @@ rules:
   - pods/exec
   verbs:
   - create
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: ibm-mustgather-custom-role
+  labels:
+    app.kubernetes.io/instance: ibm-healthcheck-operator
+    app.kubernetes.io/managed-by: ibm-healthcheck-operator
+    app.kubernetes.io/name: ibm-mustgather-custom-role
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ''
+  resources:
+  - pods/exec
+  verbs:
+  - create

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -49,3 +49,20 @@ roleRef:
   kind: ClusterRole
   name: ibm-mustgather-admin
   apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ibm-mustgather-custom-sa
+  labels:
+    app.kubernetes.io/instance: ibm-healthcheck-operator
+    app.kubernetes.io/managed-by: ibm-healthcheck-operator
+    app.kubernetes.io/name: ibm-mustgather-custom-sa
+subjects:
+- kind: ServiceAccount
+  name: ibm-mustgather-custom-sa
+  namespace: ibm-healthcheck-operator
+roleRef:
+  kind: ClusterRole
+  name: ibm-mustgather-custom-role
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/service_account.yaml
+++ b/deploy/service_account.yaml
@@ -26,3 +26,13 @@ metadata:
     app.kubernetes.io/instance: ibm-healthcheck-operator
     app.kubernetes.io/managed-by: ibm-healthcheck-operator
     app.kubernetes.io/name: ibm-mustgather-admin
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ibm-mustgather-custom-sa
+  labels:
+    app.kubernetes.io/instance: ibm-healthcheck-operator
+    app.kubernetes.io/managed-by: ibm-healthcheck-operator
+    app.kubernetes.io/name: ibm-mustgather-custom-sa

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	go.uber.org/zap v1.18.1 // indirect
 	golang.org/x/net v0.0.0-20210614182718-04defd469f4e // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.20.2
 	k8s.io/apimachinery v0.20.2
 	k8s.io/client-go v12.0.0+incompatible

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/IBM/ibm-healthcheck-operator
 
-go 1.16
+go 1.17
 
 require (
 	github.com/emicklei/go-restful v2.9.6+incompatible // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/IBM/ibm-healthcheck-operator
 
-go 1.17
+go 1.16
 
 require (
 	github.com/emicklei/go-restful v2.9.6+incompatible // indirect

--- a/manifests/ibm-mustgather-customscript-default.yaml
+++ b/manifests/ibm-mustgather-customscript-default.yaml
@@ -1,0 +1,24 @@
+###############################################################################
+# Licensed Materials - Property of IBM
+# 5737-E67
+# (C) Copyright IBM Corporation 2019, 2020 All Rights Reserved
+# US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+###############################################################################
+
+### This configmap is used to keep the default custom image location for the components who doesn't bring their own configmap
+### We recommend the product to bring their own configmap (with standard name , labels etc)
+###
+### Example of configmap data
+#####################################################
+#### data:
+###    comp: comp image location (with SHA manifest)
+###    component: component-image-location@sha256
+###    mycomp: quay.io/ujjwalchk_it/operator@sha256:a56fd4d
+#####################################################
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ibm-mustgather-customscript-default
+data:
+immutable: true

--- a/pkg/controller/mustgatherservice/mustgatherservice.go
+++ b/pkg/controller/mustgatherservice/mustgatherservice.go
@@ -22,11 +22,11 @@ import (
 	"reflect"
 
 	operatorv1alpha1 "github.com/IBM/ibm-healthcheck-operator/pkg/apis/operator/v1alpha1"
-	"gopkg.in/yaml.v2"
 
 	common "github.com/IBM/ibm-healthcheck-operator/pkg/controller/common"
 	constant "github.com/IBM/ibm-healthcheck-operator/pkg/controller/constant"
 
+	"gopkg.in/yaml.v2"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"

--- a/pkg/controller/mustgatherservice/mustgatherservice.go
+++ b/pkg/controller/mustgatherservice/mustgatherservice.go
@@ -17,10 +17,12 @@ package mustgatherservice
 
 import (
 	"context"
+	"io/ioutil"
 	"os"
 	"reflect"
 
 	operatorv1alpha1 "github.com/IBM/ibm-healthcheck-operator/pkg/apis/operator/v1alpha1"
+	"gopkg.in/yaml.v2"
 
 	common "github.com/IBM/ibm-healthcheck-operator/pkg/controller/common"
 	constant "github.com/IBM/ibm-healthcheck-operator/pkg/controller/constant"
@@ -45,6 +47,8 @@ var trueVar = true
 var falseVar = false
 
 var mustGatherResourceName = "must-gather-service"
+
+var mustGatherCustomCMName = "ibm-mustgather-customscript-default"
 
 var commonSecurityContext = corev1.SecurityContext{
 	AllowPrivilegeEscalation: &falseVar,
@@ -344,6 +348,55 @@ func (r *ReconcileMustGatherService) desiredMustGatherServiceService(instance *o
 	return svc
 }
 
+func (r *ReconcileMustGatherService) createOrUpdateMustGatherServiceConfigmap(instance *operatorv1alpha1.MustGatherService) error {
+	appName := mustGatherResourceName
+	reqLogger := log.WithValues("MustGatherService.Namespace", instance.Namespace, "MustGatherService.Name", instance.Name)
+	labels := labelsForMustGatherServiceCustomCM(appName, instance.Name)
+
+	//read configmap from yaml
+	yamlFile, err := os.Open("/manifests/ibm-mustgather-customscript-default.yaml")
+	if err != nil {
+		reqLogger.Error(err, "Error opening mustgather custom config file")
+	}
+	// defer the closing of our jsonFile so that we can parse it later on
+	defer yamlFile.Close()
+	byteValue, _ := ioutil.ReadAll(yamlFile)
+
+	cm := new(corev1.ConfigMap)
+	if err := yaml.Unmarshal(byteValue, cm); err != nil {
+		reqLogger.Error(err, "Error parsing the configmap value from /manifests/ibm-mustgather-customscript-default.yaml")
+		return err
+	}
+	yamlFile.Close()
+
+	//setup configmap name, namespace and labels
+	cm.ObjectMeta.Name = mustGatherCustomCMName
+	cm.ObjectMeta.Namespace = instance.Namespace
+	cm.ObjectMeta.Labels = labels
+
+	// Set mustgatherservice instance as the owner and controller
+	if err := controllerutil.SetControllerReference(instance, cm, r.scheme); err != nil {
+		reqLogger.Error(err, "SetControllerReference failed", "configmap.Namespace", cm.Namespace, "configmap.Name", cm.Name)
+	}
+
+	// Check if the configmap already exists, if not create a new one
+	found := &corev1.ConfigMap{}
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: cm.Name, Namespace: cm.Namespace}, found)
+	if err != nil && errors.IsNotFound(err) {
+		// Define a new configmap
+		reqLogger.Info("Creating a new configmap", "configmap.Namespace", cm.Namespace, "configmap.Name", cm.Name)
+		if err := r.client.Create(context.TODO(), cm); err != nil {
+			reqLogger.Error(err, "Failed to create new configmap", "configmap.Namespace", cm.Namespace, "configmap.Name", cm.Name)
+			return err
+		}
+	} else if err != nil {
+		reqLogger.Error(err, "Failed to get configmap", "configmap.Namespace", found.Namespace, "configmap.Name", found.Name)
+		return err
+	}
+
+	return nil
+}
+
 func (r *ReconcileMustGatherService) createOrUpdateMustGatherServiceIngress(instance *operatorv1alpha1.MustGatherService) error {
 	appName := mustGatherResourceName
 	reqLogger := log.WithValues("MustGatherService.Namespace", instance.Namespace, "MustGatherService.Name", instance.Name)
@@ -557,6 +610,17 @@ func labelsForMustGatherService(name string, releaseName string) map[string]stri
 		"app.kubernetes.io/name":       name,
 		"app.kubernetes.io/instance":   releaseName,
 		"app.kubernetes.io/managed-by": "",
+	}
+}
+
+func labelsForMustGatherServiceCustomCM(name string, releaseName string) map[string]string {
+	return map[string]string{
+		"app":                          name,
+		"release":                      releaseName,
+		"app.kubernetes.io/name":       name,
+		"app.kubernetes.io/instance":   releaseName,
+		"app.kubernetes.io/managed-by": "",
+		"serviceability-addon":         "default",
 	}
 }
 

--- a/pkg/controller/mustgatherservice/mustgatherservice_controller.go
+++ b/pkg/controller/mustgatherservice/mustgatherservice_controller.go
@@ -95,6 +95,15 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
+	// Configmap
+	err = c.Watch(&source.Kind{Type: &corev1.ConfigMap{}}, &handler.EnqueueRequestForOwner{
+		IsController: true,
+		OwnerType:    &operatorv1alpha1.MustGatherService{},
+	})
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -152,6 +161,11 @@ func (r *ReconcileMustGatherService) Reconcile(request reconcile.Request) (recon
 
 	if err = r.createOrUpdateMustGatherServiceIngress(instance); err != nil {
 		reqLogger.Error(err, "Failed to create or update Ingress for mustgather service")
+		return reconcile.Result{}, err
+	}
+
+	if err = r.createOrUpdateMustGatherServiceConfigmap(instance); err != nil {
+		reqLogger.Error(err, "Failed to create or update default custom configmap for mustgather service")
 		return reconcile.Result{}, err
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This change is to support must-gather to include and execute custom script that is being provided by components as image , which we will dynamically pull and execute during runtime based on the inputs (-- gather -c component -s ex)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/48784

