### PR TITLE
Adding SCC constraint to ibm-healthcheck-operator-cluster SA

### DIFF
--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.16.0/ibm-healthcheck-operator.v3.16.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.16.0/ibm-healthcheck-operator.v3.16.0.clusterserviceversion.yaml
@@ -259,9 +259,13 @@ spec:
           - deletecollection
         - apiGroups:
           - ''
+          - security.openshift.io
+          resourceNames:
+          - restricted
           resources:
           - pods
           - nodes
+          - securitycontextconstraints
           verbs:
           - get
           - list


### PR DESCRIPTION
Added CSVSpecific SCC constraint in below version csv file.
### deploy/olm-catalog/ibm-healthcheck-operator/3.16.0/ibm-healthcheck-operator.v3.16.0.clusterserviceversion.yaml