### PR TITLE
Removed CSVDefinesCRDWithLicenseParameter rule for 3.15.0 release

### DIFF
--- a/deploy/olm-catalog/ibm-healthcheck-operator/3.16.0/ibm-healthcheck-operator.v3.16.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-healthcheck-operator/3.16.0/ibm-healthcheck-operator.v3.16.0.clusterserviceversion.yaml
@@ -207,14 +207,7 @@ spec:
         path: healthService
       - description: Memcached defines the desired state of HealthService.Memcached
         displayName: Memcached
-        path: memcached
-      - description: This is used by license.accept tool for the GUI instructions
-        displayName: License Accept
-        path: license.accept
-        value:
-        - false
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:checkbox 
+        path: memcached 
       statusDescriptors:
       - description: HealthCheckNodes are the names of the Healch Service pods
         displayName: Healch Service Nodes


### PR DESCRIPTION
Removed the CSVDefinesCRDWithLicenseParameter lint fix , which would be rather added as exception for Feb release.